### PR TITLE
Package as a nix flake, fetch grammars and queries from Helix.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use_flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703499205,
+        "narHash": "sha256-lF9rK5mSUfIZJgZxC3ge40tp1gmyyOXZ+lRY3P8bfbg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e1fa12d4f6c6fe19ccb59cac54b5b3f25e160870",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,45 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1705332421,
+        "narHash": "sha256-USpGLPme1IuqG78JNqSaRabilwkCyHmVWY0M9vYyqEA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "83cb93d6d063ad290beee669f4badf9914cc16ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1707978135,
+        "narHash": "sha256-Xje6vjTcVUfPg3+X4PUSlgDxA/MSqzmtjOTW47NRwwM=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "09ef6ec17141904ca28ddd62f2697f63c2aaa799",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,7 +58,41 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1704161960,
+        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1703499205,
         "narHash": "sha256-lF9rK5mSUfIZJgZxC3ge40tp1gmyyOXZ+lRY3P8bfbg=",
@@ -36,11 +110,45 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "devshell": "devshell",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1707925466,
+        "narHash": "sha256-2xxcezb4tvssbVCU69DnTDSMB2lqwEp63JNQt8zuzcs=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "dba59970bcccfb3c6fc16ea0d0d79da875f22316",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "tree-sitter meets Kakoune";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+  # Get Linux x86_64, Linux aarch64, macOS x86_64 and macOS aarch64 for free.
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # Read the kak-tree-sitter version from Cargo.toml.
+      version = (builtins.fromTOML (builtins.readFile ./kak-tree-sitter/Cargo.toml)).package.version;
+
+      # We use Helix sources to fetch and build grammars and queries.
+      helix = {
+        version = "23.10-dev";
+        repo = pkgs.fetchFromGitHub {
+          owner = "helix-editor";
+          repo = "helix";
+          rev = "85fce2f5b6c9f35ab9d3361f3933288a28db83d4";
+          hash = "sha256-TNEsdsaCG1+PvGINrV/zw7emzwpfWiml4b77l2n5UEI=";
+        };
+      };
+
+      # Description of how to build the kak-tree-sitter.
+      derivation = {
+        rustPlatform,
+        git,
+      }:
+        rustPlatform.buildRustPackage {
+          inherit version;
+          pname = "kak-tree-sitter";
+          src = ./.;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+          # We only need to build kak-tree-sitter, no need to waste time on ktsctl.
+          cargoBuildFlags = ["--package=kak-tree-sitter"];
+          nativeBuildInputs = [git];
+        };
+
+      # Build or "realize" the derivation.
+      package = pkgs.callPackage derivation {};
+
+      # Fetch and build grammars and queries from Helix.
+      grammars = pkgs.callPackage (import ./gen-grammars.nix {inherit helix;}) {};
+
+      # Generate kak-tree-sitter config.toml using tree-sitter queries from Helix.
+      config = pkgs.callPackage (import ./gen-config.nix {inherit helix;}) {};
+
+      # Final package to assemble everything.
+      final = pkgs.runCommandLocal "kak-tree-sitter-full" {} ''
+        mkdir -p $out/share/kak-tree-sitter
+
+        cp --dereference             ${config}/config.toml $out/share/kak-tree-sitter/config.toml
+        cp --dereference --recursive ${grammars}/grammars  $out/share/kak-tree-sitter/grammars
+        cp --dereference --recursive ${grammars}/queries   $out/share/kak-tree-sitter/queries
+        cp --dereference --recursive ${package}/bin        $out/bin
+      '';
+    in
+      # See: https://nixos.wiki/wiki/Flakes#Output_schema
+      {
+        formatter = pkgs.alejandra;
+
+        packages.default = final;
+
+        apps.default = {
+          type = "app";
+          program = "${final}/bin/kak-tree-sitter";
+        };
+      });
+}

--- a/gen-config.nix
+++ b/gen-config.nix
@@ -1,0 +1,136 @@
+{helix}: {pkgs, ...}: let
+  groups = [
+    "attribute"
+    "comment"
+    "comment.block"
+    "comment.line"
+    "constant"
+    "constant.builtin"
+    "constant.builtin.boolean"
+    "constant.character"
+    "constant.character.escape"
+    "constant.macro"
+    "constant.numeric"
+    "constant.numeric.float"
+    "constant.numeric.integer"
+    "constructor"
+    "diff.plus"
+    "diff.minus"
+    "diff.delta"
+    "diff.delta.moved"
+    "embedded"
+    "error"
+    "function"
+    "function.builtin"
+    "function.macro"
+    "function.method"
+    "function.special"
+    "hint"
+    "include"
+    "info"
+    "keyword"
+    "keyword.conditional"
+    "keyword.control"
+    "keyword.control.conditional"
+    "keyword.control.except"
+    "keyword.control.exception"
+    "keyword.control.import"
+    "keyword.control.repeat"
+    "keyword.control.return"
+    "keyword.directive"
+    "keyword.function"
+    "keyword.operator"
+    "keyword.special"
+    "keyword.storage"
+    "keyword.storage.modifier"
+    "keyword.storage.modifier.mut"
+    "keyword.storage.modifier.ref"
+    "keyword.storage.type"
+    "label"
+    "load"
+    "markup.bold"
+    "markup.heading"
+    "markup.heading.1"
+    "markup.heading.2"
+    "markup.heading.3"
+    "markup.heading.4"
+    "markup.heading.5"
+    "markup.heading.6"
+    "markup.heading.marker"
+    "markup.italic"
+    "markup.link.label"
+    "markup.link.text"
+    "markup.link.url"
+    "markup.link.uri"
+    "markup.list.checked"
+    "markup.list.numbered"
+    "markup.list.unchecked"
+    "markup.list.unnumbered"
+    "markup.quote"
+    "markup.raw"
+    "markup.raw.block"
+    "markup.raw.inline"
+    "markup.strikethrough"
+    "namespace"
+    "operator"
+    "punctuation"
+    "punctuation.bracket"
+    "punctuation.delimiter"
+    "punctuation.special"
+    "special"
+    "string"
+    "string.escape"
+    "string.regex"
+    "string.regexp"
+    "string.special"
+    "string.special.path"
+    "string.special.symbol"
+    "string.symbol"
+    "tag"
+    "tag.error"
+    "text"
+    "type"
+    "type.builtin"
+    "type.enum.variant"
+    "variable"
+    "variable.builtin"
+    "variable.other.member"
+    "variable.other.member"
+    "variable.parameter"
+    "warning"
+  ];
+
+  # Even though we use Helix to compile grammars, we still need the config.toml, otherwise kak-tree-sitter will fail.
+  queries = builtins.attrNames (builtins.readDir "${helix.repo}/runtime/queries");
+  languages =
+    builtins.map (n: {
+      name = "${n}";
+      value = {
+        grammar = {
+          url = "";
+          pin = "";
+          path = "";
+          compile = "";
+          compile_args = [];
+          compile_flags = [];
+          link = "";
+          link_args = [];
+          link_flags = [];
+        };
+        queries = {
+          url = "";
+          pin = "";
+          path = "";
+        };
+      };
+    })
+    queries;
+  config = (pkgs.formats.toml {}).generate "kak-tree-sitter-config.toml" {
+    language = builtins.listToAttrs languages;
+    highlight = {inherit groups;};
+  };
+in
+  pkgs.runCommandLocal "kak-tree-sitter-config" {} ''
+    mkdir $out
+    ln -s ${config} $out/config.toml
+  ''

--- a/gen-grammars.nix
+++ b/gen-grammars.nix
@@ -1,0 +1,121 @@
+# Fetch and build grammars from https://github.com/helix-editor/helix/languages.toml.
+# The code is borrowed and reworked from: https://github.com/helix-editor/helix/blob/85fce2f5b6c9f35ab9d3361f3933288a28db83d4/grammars.nix.
+{helix}: {
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  ...
+}: let
+  buildGrammar = grammar:
+    stdenv.mkDerivation {
+      # See: https://github.com/NixOS/nixpkgs/blob/fbdd1a7c0bc29af5325e0d7dd70e804a972eb465/pkgs/development/tools/parsing/tree-sitter/grammar.nix.
+      pname = "tree-sitter-${grammar.name}";
+      version = grammar.source.rev;
+
+      src = let
+        isGitHubGrammar = grammar: lib.hasPrefix "https://github.com" grammar.source.git;
+        sourceGitHub = let
+          match = builtins.match "https://github\.com/([^/]*)/([^/]*)/?" grammar.source.git;
+          owner = builtins.elemAt match 0;
+          repo = builtins.elemAt match 1;
+        in
+          builtins.fetchTree {
+            inherit (grammar.source) rev;
+            inherit owner repo;
+            type = "github";
+          };
+        sourceGit = builtins.fetchTree {
+          type = "git";
+          url = grammar.source.git;
+          rev = grammar.source.rev;
+          ref = grammar.source.ref or "HEAD";
+          shallow = true;
+        };
+      in
+        if isGitHubGrammar grammar
+        then sourceGitHub
+        else sourceGit;
+
+      sourceRoot =
+        if builtins.hasAttr "subpath" grammar.source
+        then "source/${grammar.source.subpath}"
+        else "source";
+
+      dontConfigure = true;
+
+      FLAGS = [
+        "-Isrc"
+        "-g"
+        "-O3"
+        "-fPIC"
+        "-fno-exceptions"
+        "-Wl,-z,relro,-z,now"
+      ];
+
+      NAME = grammar.name;
+
+      buildPhase = ''
+        runHook preBuild
+
+        if [[ -e src/scanner.cc ]]; then
+          $CXX -c src/scanner.cc -o scanner.o $FLAGS
+        elif [[ -e src/scanner.c ]]; then
+          $CC -c src/scanner.c -o scanner.o $FLAGS
+        fi
+
+        $CC -c src/parser.c -o parser.o $FLAGS
+        $CXX -shared -o $NAME.so *.o
+
+        ls -al
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir $out
+        mv $NAME.so $out/
+        runHook postInstall
+      '';
+
+      # Strip failed on darwin: strip: error: symbols referenced by indirect symbol table entries that can't be stripped
+      fixupPhase = lib.optionalString stdenv.isLinux ''
+        runHook preFixup
+        $STRIP $out/$NAME.so
+        runHook postFixup
+      '';
+    };
+in
+  stdenv.mkDerivation rec {
+    pname = "consolidated-grammars";
+    version = helix.version;
+
+    src = helix.repo;
+
+    dontUnpack = true;
+    dontPatch = true;
+    dontConfigure = true;
+
+    buildPhase = let
+      languagesConfig = builtins.fromTOML (builtins.readFile "${src}/languages.toml");
+      isGitGrammar = grammar:
+        builtins.hasAttr "source" grammar
+        && builtins.hasAttr "git" grammar.source
+        && builtins.hasAttr "rev" grammar.source;
+      gitGrammars = builtins.filter isGitGrammar languagesConfig.grammar;
+      builtGrammars =
+        builtins.map (grammar: {
+          inherit (grammar) name;
+          value = buildGrammar grammar;
+        })
+        gitGrammars;
+      grammarLinks =
+        lib.mapAttrsToList
+        (name: artifact: "ln -s ${artifact}/${name}.so $out/grammars/${name}.so")
+        (lib.filterAttrs (n: v: lib.isDerivation v) (builtins.listToAttrs builtGrammars));
+    in ''
+      mkdir -p $out/grammars
+      ${builtins.concatStringsSep "\n" grammarLinks}
+      ln -s ${src}/runtime/queries $out/queries
+    '';
+  }

--- a/kak-tree-sitter-config/src/lib.rs
+++ b/kak-tree-sitter-config/src/lib.rs
@@ -78,13 +78,10 @@ pub struct LanguagesConfig {
 impl LanguagesConfig {
   /// Get the directory with built-in grammars and queries relative to the binary.
   fn get_builtin_dir() -> Option<PathBuf> {
-    let exec = match std::env::current_exe() {
-      Ok(path) => Some(path),
-      Err(_) => None,
-    }?;
-    exec
+    std::env::current_exe()
+      .ok()?
+      .parent()?
       .parent()
-      .and_then(|bin| bin.parent())
       .map(|dir| dir.join("share/kak-tree-sitter"))
   }
 

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
 
 fn start() -> Result<(), OhNo> {
   let cli = Cli::parse();
-  let config = match Config::load_from_xdg() {
+  let config = match Config::load() {
     Ok(config) => config,
     Err(err) => {
       eprintln!("configuration error; will be using empty configuration: {err}");

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -647,7 +647,7 @@ impl UnixHandler {
   }
 
   fn reload(&mut self, fifo_handler: &mut FifoHandler) {
-    let config = match Config::load_from_xdg() {
+    let config = match Config::load() {
       Ok(config) => config,
       Err(err) => {
         log::error!("reloading config failed: {err}");

--- a/ktsctl/src/main.rs
+++ b/ktsctl/src/main.rs
@@ -93,7 +93,7 @@ fn kak_tree_sitter_data_dir() -> Result<PathBuf, AppError> {
 
 fn start() -> Result<(), AppError> {
   let cli = Cli::parse();
-  let config = Config::load_from_xdg()?;
+  let config = Config::load()?;
 
   // check the runtime dir exists
   let dir = runtime_dir()?;


### PR DESCRIPTION
Partially solves https://github.com/phaazon/kak-tree-sitter/issues/22.

Depend on `helix` sources to fetch and build `tree-sitter` grammars and queries. Also, use `helix` `tree-sitter` queries to generate the `config.toml`.

Had to update the `kak-tree-sitter-config` to be able to embed built-in grammars and queries. The new logic now is: try to load first from `XDG_*` as before, and fallback to built-in ones from `helix` if failed to load, similar to what Kakoune does with `autoload` directory.

To try out, ensure `nix` installed with `flakes` enabled, and then:
```console
$ nix run github:igor-ramazanov/kak-tree-sitter/nix-flake -- --help

Usage: kak-tree-sitter [OPTIONS]
Options:
  -k, --kakoune
          Whether we start from Kakoune and then we should issue an initial request for setup
  -s, --server
          Start the server, if not already started
  -d, --daemonize
          Try to daemonize, if not already done
      --session <SESSION>
          Kakoune session to connect to
  -c, --client <CLIENT>
          Kakoune client to connect with, if any
  -r, --request <REQUEST>
          JSON-serialized request
  -v, --verbose...
          Verbosity.
          Can be accumulated to get more verbosity. Without this flag, logging is disabled. Then, for each applicaton of the flag, the obtained verbosity follows this order: error, warn, info, debug, trace. Thus, if you use -v, you will only get error messages. If you use -vv, you will also see warnings. The maximum verbosity is achieved with -vvvvv for trace logs.
  -h, --help
          Print help (see a summary with '-h')
  -V, --version
          Print version
```