### PR TITLE
Textobjects mk2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "thiserror",
  "tree-sitter",
  "tree-sitter-highlight",
+ "tree-sitter-rust",
  "unicode-segmentation",
 ]
 
@@ -608,6 +609,16 @@ checksum = "042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc"
 dependencies = [
  "regex",
  "thiserror",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+dependencies = [
+ "cc",
  "tree-sitter",
 ]
 

--- a/kak-tree-sitter/Cargo.toml
+++ b/kak-tree-sitter/Cargo.toml
@@ -30,3 +30,6 @@ thiserror = "1.0.57"
 tree-sitter = "0.20.10"
 tree-sitter-highlight = "0.20.1"
 unicode-segmentation = "1.11.0"
+
+[dev-dependencies]
+tree-sitter-rust = "0.20.4"

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -96,9 +96,16 @@ define-command kak-tree-sitter-req-highlight-buffer -docstring 'Highlight the cu
 
 define-command kak-tree-sitter-req-textobjects -params 1 %{
   evaluate-commands -no-hooks %{
-    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selection"": ""%val{selection_desc}"", ""textobject_type"": ""%arg{1}"" }"
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selection"": ""%val{selection_desc}"", ""textobject_type"": ""%arg{1}"", ""object_flags"": ""%val{object_flags}"", ""select_mode"": ""%val{select_mode}"" }"
     write %opt{kts_buf_fifo_path}
   }
+}
+
+define-command -hidden kak-tree-sitter-text-objects-enable %{
+  map -docstring 'function (tree-sitter)'  buffer object f   '<a-;> kak-tree-sitter-req-textobjects function<ret>'
+  map -docstring 'class (tree-sitter)'     buffer object t   '<a-;> kak-tree-sitter-req-textobjects class<ret>'
+  map -docstring 'comment (tree-sitter)'   buffer object '#' '<a-;> kak-tree-sitter-req-textobjects comment<ret>'
+  map -docstring 'parameter (tree-sitter)' buffer object 'v' '<a-;> kak-tree-sitter-req-textobjects parameter<ret>'
 }
 
 # Enable highlighting for the current buffer.
@@ -128,6 +135,7 @@ define-command -hidden kak-tree-sitter-set-lang %{
 define-command kak-tree-sitter-req-enable -docstring 'Send request to enable tree-sitter support' %{
   kak-tree-sitter-set-lang
   echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""try_enable_highlight"", ""lang"": ""%opt{kts_lang}"", ""client"": ""%val{client}"" }"
+  kak-tree-sitter-textobjects-enable
 }
 
 # Initiate request.

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -96,7 +96,7 @@ define-command kak-tree-sitter-req-highlight-buffer -docstring 'Highlight the cu
 
 define-command kak-tree-sitter-req-textobjects -params 1 %{
   evaluate-commands -no-hooks %{
-    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selection"": ""%val{selection_desc}"", ""textobject_type"": ""%arg{1}"", ""object_flags"": ""%val{object_flags}"", ""select_mode"": ""%val{select_mode}"" }"
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selections"": ""%val{selections_desc}"", ""textobject_type"": ""%arg{1}"", ""object_flags"": ""%val{object_flags}"", ""select_mode"": ""%val{select_mode}"" }"
     write %opt{kts_buf_fifo_path}
   }
 }

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -101,11 +101,26 @@ define-command kak-tree-sitter-req-textobjects -params 1 %{
   }
 }
 
-define-command -hidden kak-tree-sitter-text-objects-enable %{
-  map -docstring 'function (tree-sitter)'  buffer object f   '<a-;> kak-tree-sitter-req-textobjects function<ret>'
-  map -docstring 'class (tree-sitter)'     buffer object t   '<a-;> kak-tree-sitter-req-textobjects class<ret>'
-  map -docstring 'comment (tree-sitter)'   buffer object '#' '<a-;> kak-tree-sitter-req-textobjects comment<ret>'
-  map -docstring 'parameter (tree-sitter)' buffer object 'v' '<a-;> kak-tree-sitter-req-textobjects parameter<ret>'
+define-command kak-tree-sitter-req-select -params 1 %{
+  evaluate-commands -no-hooks %{
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""select_text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selections"": ""%val{selections_desc}"", ""textobject_type"": ""%arg{1}"" }"
+    write %opt{kts_buf_fifo_path}
+  }
+}
+
+declare-user-mode kak-tree-sitter
+
+# Enable textobject mappings
+define-command -hidden kak-tree-sitter-textobjects-enable %{
+  map -docstring 'function (tree-sitter)'         buffer object f   '<a-;> kak-tree-sitter-req-textobjects function<ret>'
+  map -docstring 'class (tree-sitter)'            buffer object t   '<a-;> kak-tree-sitter-req-textobjects class<ret>'
+  map -docstring 'parameter (tree-sitter)'        buffer object v '<a-;> kak-tree-sitter-req-textobjects parameter<ret>'
+  map -docstring 'comment (tree-sitter)'          buffer object '#' '<a-;> kak-tree-sitter-req-textobjects comment<ret>'
+  
+  map -docstring 'narrow selection to functions'  buffer kak-tree-sitter f   ':kak-tree-sitter-req-select function<ret>'
+  map -docstring 'narrow selection to classs'     buffer kak-tree-sitter t   ':kak-tree-sitter-req-select class<ret>'
+  map -docstring 'narrow selection to parameters' buffer kak-tree-sitter v   ':kak-tree-sitter-req-select parameter<ret>'
+  map -docstring 'narrow selection to comments'   buffer kak-tree-sitter '#' ':kak-tree-sitter-req-select comment<ret>'
 }
 
 # Enable highlighting for the current buffer.

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -94,6 +94,13 @@ define-command kak-tree-sitter-req-highlight-buffer -docstring 'Highlight the cu
   }
 }
 
+define-command kak-tree-sitter-req-textobjects -params 1 %{
+  evaluate-commands -no-hooks %{
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selection"": ""%val{selection_desc}"", ""textobject_type"": ""%arg{1}"" }"
+    write %opt{kts_buf_fifo_path}
+  }
+}
+
 # Enable highlighting for the current buffer.
 # 
 # This command does a couple of things, among removing the « default » highlighting (Kakoune based) of the buffer and

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -70,4 +70,7 @@ pub enum OhNo {
 
   #[error("highlight error: {err}")]
   HighlightError { err: String },
+  
+  #[error("textobject error: {err}")]
+  TextobjectError { err: String },
 }

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -65,6 +65,9 @@ pub enum OhNo {
   #[error("cannot send request: {err}")]
   CannotSendRequest { err: String },
 
+  #[error("cannot parse buffer")]
+  CannotParseBuffer,
+
   #[error("highlight error: {err}")]
   HighlightError { err: String },
 }

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,10 +1,14 @@
+use std::collections::{hash_map::Entry, HashMap};
+
 use kak_tree_sitter_config::Config;
 
 use crate::{
   error::OhNo,
-  highlighting::{BufferId, Highlighters},
-  languages::Languages,
+  highlighting::BufferId,
+  kak,
+  languages::{Language, Languages},
   response::Response,
+  tree_sitter_state::TreeState,
 };
 
 /// Type responsible for handling requests.
@@ -12,8 +16,8 @@ use crate::{
 /// This type is stateful, as requests might have side-effect (i.e. tree-sitter parsing generates trees/highlighters
 /// that can be reused, for instance).
 pub struct Handler {
-  /// Map a highlighter to a [`BufferId`].
-  highlighters: Highlighters,
+  /// Tree-sitter trees associated with a [`BufferId`].
+  trees: HashMap<BufferId, TreeState>,
 
   /// Known languages.
   langs: Languages,
@@ -21,13 +25,31 @@ pub struct Handler {
 
 impl Handler {
   pub fn new(config: &Config) -> Result<Self, OhNo> {
-    let highlighters = Highlighters::new();
+    let trees = HashMap::default();
     let langs = Languages::load_from_dir(config)?;
 
-    Ok(Self {
-      highlighters,
-      langs,
-    })
+    Ok(Self { trees, langs })
+  }
+
+  /// Ensure we have a parsed tree for this buffer id and buffer content.
+  fn compute_tree<'a>(
+    tree_states: &'a mut HashMap<BufferId, TreeState>,
+    lang: &Language,
+    buffer_id: BufferId,
+    buf: &str,
+  ) -> Result<&'a mut TreeState, OhNo> {
+    let ts = match tree_states.entry(buffer_id) {
+      Entry::Vacant(entry) => entry.insert(TreeState::new(lang)?),
+
+      Entry::Occupied(mut entry) => {
+        if entry.get().lang() != lang.lang() {
+          entry.insert(TreeState::new(lang)?);
+        }
+        entry.into_mut()
+      }
+    };
+    ts.update(buf);
+    Ok(ts)
   }
 
   pub fn handle_try_enable_highlight(
@@ -68,24 +90,88 @@ impl Handler {
     );
 
     let buffer_id = BufferId::new(session_name, buffer);
-    self.handle_highlight_req(buffer_id, lang_name, timestamp, buf)
-  }
 
-  fn handle_highlight_req(
-    &mut self,
-    buffer_id: BufferId,
-    lang_name: &str,
-    timestamp: u64,
-    buf: &str,
-  ) -> Result<Response, OhNo> {
     if let Some(lang) = self.langs.get(lang_name) {
-      self
-        .highlighters
-        .highlight(lang, &self.langs, buffer_id, timestamp, buf)
+      let tree_state = Self::compute_tree(&mut self.trees, &lang, buffer_id, buf)?;
+
+      // tree_state.query(&lang.hl_config.query, buf);
+      // log::info!("trying injections now…");
+      // Ok(Response::status("unimplemented"));
+
+      Ok(Response::Highlights {
+        timestamp,
+        ranges: tree_state.highlight(lang, &self.langs, buf)?,
+      })
     } else {
       Ok(Response::status(format!(
         "unsupported language: {lang_name}"
       )))
+    }
+  }
+
+  pub fn handle_text_objects(
+    &mut self,
+    session_name: &str,
+    buffer: &str,
+    lang_name: &str,
+    timestamp: u64,
+    buf: &str,
+    selection: kak::LocRange,
+    textobject_type: String,
+  ) -> Result<Response, OhNo> {
+    log::debug!(
+      "text_objects for session {session_name}, buffer {buffer}, lang {lang_name}, timestamp {timestamp}"
+    );
+    let buffer_id = BufferId::new(session_name, buffer);
+    let Some(lang) = self.langs.get(lang_name) else {
+      return Ok(Response::status(format!(
+        "unsupported language: {lang_name}"
+      )));
+    };
+    let Some(query) = lang.textobjects_query.as_ref() else {
+      return Ok(Response::status("language does not support textobjects"));
+    };
+
+    let tree_state = Self::compute_tree(&mut self.trees, lang, buffer_id, buf)?;
+    let mut cursor = tree_sitter::QueryCursor::new();
+    let names = query.capture_names();
+    let captures = cursor.captures(query, tree_state.tree().root_node(), buf.as_bytes());
+    let Some(name_idx) = query.capture_index_for_name(&textobject_type) else {
+      return Ok(Response::status(
+        "language does not support this textobject",
+      ));
+    };
+
+    // Iterator over all code ranges that match the textobject type
+    let ranges = captures.filter_map(|(query_match, _size)| {
+      let mut iter = query_match
+        .captures
+        .iter()
+        .filter_map(|x| (x.index == name_idx).then_some(x.node));
+      if let Some(first) = iter.next() {
+        let last = iter.last().unwrap_or(first);
+        let range = first.start_position()..last.end_position();
+        let byte_len = first.start_byte().abs_diff(last.end_byte());
+        Some((kak::LocRange::from(range), byte_len))
+      } else {
+        None
+      }
+    });
+
+    // Objects that contain the current selection and are not equal to it. This lets us call the function repeatedly to expand the selection
+    let ranges =
+      ranges.filter(|(range, byte_len)| range.contains_range(&selection) && *range != selection);
+    // We want the innermost object, i.e. the shortest one that contains the selection
+    let res = ranges.min_by_key(|(range, byte_len)| *byte_len);
+
+    if let Some((range, _byte_len)) = res {
+      Ok(Response::TextObject {
+        timestamp,
+        obj_type: textobject_type,
+        range,
+      })
+    } else {
+      Ok(Response::status("No textobject found"))
     }
   }
 }

--- a/kak-tree-sitter/src/kak.rs
+++ b/kak-tree-sitter/src/kak.rs
@@ -58,10 +58,13 @@ pub struct LocRange {
 
 impl<T: Into<Loc>> From<Range<T>> for LocRange {
   fn from(value: Range<T>) -> Self {
-    Self {
+    let mut res =  Self {
       anchor: value.start.into(),
       cursor: value.end.into(),
-    }
+    };
+    // Tree sitter ranges are excluding the end, kak ranges include it
+    res.cursor.col_byte = res.cursor.col_byte.saturating_sub(1);
+    res
   }
 }
 

--- a/kak-tree-sitter/src/kak.rs
+++ b/kak-tree-sitter/src/kak.rs
@@ -1,0 +1,115 @@
+use std::ops::Range;
+
+use serde::Deserialize;
+
+/// Kakoune location. Line and col_byte are zero indexed here,
+/// but one indexed when formatted and parsed
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Loc {
+  pub line: usize,
+  pub col_byte: usize,
+}
+
+impl std::fmt::Display for Loc {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}.{}", self.line + 1, self.col_byte + 1)
+  }
+}
+
+impl From<tree_sitter::Point> for Loc {
+  fn from(value: tree_sitter::Point) -> Self {
+    // The tree_sitter::Point column is also a byte offset, so this is ok
+    Self {
+      line: value.row,
+      col_byte: value.column,
+    }
+  }
+}
+
+impl From<Loc> for tree_sitter::Point {
+  fn from(value: Loc) -> Self {
+    Self {
+      row: value.line,
+      column: value.col_byte,
+    }
+  }
+}
+
+impl Loc {
+  pub fn new(line: usize, col_byte: usize) -> Self {
+    Self { line, col_byte }
+  }
+
+  /// Parse a location from kakoune in the format line.col
+  pub fn parse(s: &str) -> Option<Self> {
+    let (line, col) = s.split_once('.')?;
+    Some(Self {
+      line: line.parse::<usize>().ok()?.saturating_sub(1),
+      col_byte: col.parse::<usize>().ok()?.saturating_sub(1),
+    })
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocRange {
+  pub start: Loc,
+  pub end: Loc,
+}
+
+impl<T: Into<Loc>> From<Range<T>> for LocRange {
+  fn from(value: Range<T>) -> Self {
+    Self {
+      start: value.start.into(),
+      end: value.end.into(),
+    }
+  }
+}
+
+impl LocRange {
+  pub fn new(start: Loc, end: Loc) -> Self {
+    Self { start, end }
+  }
+
+  pub fn contains(&self, loc: Loc) -> bool {
+    loc >= self.start && loc <= self.end
+  }
+
+  pub fn contains_range(&self, range: &LocRange) -> bool {
+    self.contains(range.start) && self.contains(range.end)
+  }
+
+  /// Parse a location from kakoune in the format `a.b,c.d`, where start.line = a, start.col = b, end.line = c, end.col = d
+  pub fn parse_selection(s: &str) -> Option<Self> {
+    let (start, end) = s.split_once(',')?;
+    Some(Self {
+      start: Loc::parse(start)?,
+      end: Loc::parse(end)?,
+    })
+  }
+}
+
+impl std::fmt::Display for LocRange {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{},{}", self.start, self.end)
+  }
+}
+
+impl<'de> Deserialize<'de> for LocRange {
+  fn deserialize<D>(deserializer: D) -> Result<LocRange, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    use serde::de::Error;
+    let s = <&str>::deserialize(deserializer)?;
+    LocRange::parse_selection(s).ok_or(D::Error::custom("Could not parse LocRange"))
+  }
+}
+
+impl serde::Serialize for LocRange {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    self.to_string().serialize(serializer)
+  }
+}

--- a/kak-tree-sitter/src/kak.rs
+++ b/kak-tree-sitter/src/kak.rs
@@ -50,47 +50,65 @@ impl Loc {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LocRange {
-  pub start: Loc,
-  pub end: Loc,
+  pub anchor: Loc,
+  pub cursor: Loc,
 }
 
 impl<T: Into<Loc>> From<Range<T>> for LocRange {
   fn from(value: Range<T>) -> Self {
     Self {
-      start: value.start.into(),
-      end: value.end.into(),
+      anchor: value.start.into(),
+      cursor: value.end.into(),
     }
   }
 }
 
 impl LocRange {
-  pub fn new(start: Loc, end: Loc) -> Self {
-    Self { start, end }
+  pub fn new(anchor: Loc, cursor: Loc) -> Self {
+    Self { anchor, cursor }
   }
 
   pub fn contains(&self, loc: Loc) -> bool {
-    loc >= self.start && loc <= self.end
+    loc >= self.start() && loc <= self.end()
   }
 
   pub fn contains_range(&self, range: &LocRange) -> bool {
-    self.contains(range.start) && self.contains(range.end)
+    self.contains(range.cursor) && self.contains(range.anchor)
   }
 
   /// Parse a location from kakoune in the format `a.b,c.d`, where start.line = a, start.col = b, end.line = c, end.col = d
   pub fn parse_selection(s: &str) -> Option<Self> {
-    let (start, end) = s.split_once(',')?;
+    let (anchor, cursor) = s.split_once(',')?;
     Some(Self {
-      start: Loc::parse(start)?,
-      end: Loc::parse(end)?,
+      anchor: Loc::parse(anchor)?,
+      cursor: Loc::parse(cursor)?,
     })
+  }
+
+  pub fn start(&self) -> Loc {
+    self.cursor.min(self.anchor)
+  }
+
+  pub fn end(&self) -> Loc {
+    self.cursor.max(self.anchor)
+  }
+
+  /// Merge two selections, keeping the order of the cursor/anchor. i.e. if the cursor was at the start of the
+  /// selection before, keep it at the start of the selection after
+  pub fn extend(&self, other: LocRange) -> LocRange {
+    if self.anchor < self.cursor {
+      LocRange::new(self.start().min(other.start()), self.end().max(other.end()))
+    } else {
+      LocRange::new(self.end().max(other.end()), self.start().min(other.start()))
+    }
   }
 }
 
 impl std::fmt::Display for LocRange {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{},{}", self.start, self.end)
+    write!(f, "{},{}", self.anchor, self.cursor)
   }
 }
 
@@ -112,4 +130,47 @@ impl serde::Serialize for LocRange {
   {
     self.to_string().serialize(serializer)
   }
+}
+
+/// The flags stored in kakoune's %val{object_flags}
+#[derive(Debug, Default, Clone, Copy, serde::Serialize)]
+pub struct ObjectFlags {
+  pub to_begin: bool,
+  pub to_end: bool,
+  pub inner: bool,
+}
+
+impl ObjectFlags {
+  pub fn parse(s: &str) -> Self {
+    let mut res = Self::default();
+    for flag in s.split('|') {
+      match flag {
+        "inner" => res.inner = true,
+        "to_begin" => res.to_begin = true,
+        "to_end" => res.to_end = true,
+        _ => log::warn!("Unexpected object flag from kakoune: {flag}"),
+      }
+    }
+    res
+  }
+}
+
+impl<'de> Deserialize<'de> for ObjectFlags {
+  fn deserialize<D>(deserializer: D) -> Result<ObjectFlags, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s = <&str>::deserialize(deserializer)?;
+    Ok(ObjectFlags::parse(s))
+  }
+}
+
+/// The selection mode stored in %val{select_mode}
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum SelectMode {
+  #[default]
+  #[serde(rename = "replace")]
+  Replace,
+  #[serde(rename = "extend")]
+  Extend,
 }

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -10,6 +10,8 @@ mod request;
 mod response;
 mod server;
 mod session;
+mod tree_sitter_state;
+mod kak;
 
 use clap::Parser;
 use cli::Cli;

--- a/kak-tree-sitter/src/queries.rs
+++ b/kak-tree-sitter/src/queries.rs
@@ -7,7 +7,8 @@ pub struct Queries {
   pub highlights: Option<String>,
   pub injections: Option<String>,
   pub locals: Option<String>,
-  pub text_objects: Option<String>,
+  pub textobjects: Option<String>,
+  pub indents: Option<String>,
 }
 
 impl Queries {
@@ -17,13 +18,15 @@ impl Queries {
     let highlights = fs::read_to_string(dir.join("highlights.scm")).ok();
     let injections = fs::read_to_string(dir.join("injections.scm")).ok();
     let locals = fs::read_to_string(dir.join("locals.scm")).ok();
-    let text_objects = fs::read_to_string(dir.join("text_objects.scm")).ok();
+    let textobjects = fs::read_to_string(dir.join("textobjects.scm")).ok();
+    let indents = fs::read_to_string(dir.join("indents.scm")).ok();
 
     Queries {
       highlights,
       injections,
       locals,
-      text_objects,
+      textobjects,
+      indents,
     }
   }
 }

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -67,10 +67,12 @@ pub enum Request {
     buffer: String,
     lang: String,
     timestamp: u64,
-    /// Which textobject to look for. Format: {type,function,parameter,comment}.{inside,around}
+    /// Which textobject to look for, i.e.  type,function,parameter,comment
     textobject_type: String,
     /// Will return the smallest matching textobject that contains this selection
     selection: kak::LocRange,
+    object_flags: kak::ObjectFlags,
+    select_mode: kak::SelectMode,
   },
 }
 

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
+use crate::kak;
+
 /// Unidentified request (i.e. not linked to a given session).
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -40,7 +42,7 @@ impl UnixRequest {
 /// Request payload.
 ///
 /// Request payload are parameterized with the « origin » at which requests are expected.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Request {
   /// Try enabling highlighting for a given filetype.
@@ -59,6 +61,17 @@ pub enum Request {
     lang: String,
     timestamp: u64,
   },
+
+  TextObjects {
+    client: String,
+    buffer: String,
+    lang: String,
+    timestamp: u64,
+    /// Which textobject to look for. Format: {type,function,parameter,comment}.{inside,around}
+    textobject_type: String,
+    /// Will return the smallest matching textobject that contains this selection
+    selection: kak::LocRange,
+  },
 }
 
 impl Request {
@@ -66,6 +79,7 @@ impl Request {
     match self {
       Request::TryEnableHighlight { client, .. } => Some(client.as_str()),
       Request::Highlight { client, .. } => Some(client.as_str()),
+      Request::TextObjects { client, .. } => Some(client.as_str()),
     }
   }
 }

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -75,6 +75,18 @@ pub enum Request {
     object_flags: kak::ObjectFlags,
     select_mode: kak::SelectMode,
   },
+  
+  SelectTextObjects {
+    client: String,
+    buffer: String,
+    lang: String,
+    timestamp: u64,
+    /// Which textobject to look for, i.e. type,function,parameter,comment
+    textobject_type: String,
+    /// Space separated list of selections as kak::LocRange
+    /// For each selection, return the smallest matching textobject that contains this selection
+    selections: String,
+  },
 }
 
 impl Request {
@@ -83,6 +95,7 @@ impl Request {
       Request::TryEnableHighlight { client, .. } => Some(client.as_str()),
       Request::Highlight { client, .. } => Some(client.as_str()),
       Request::TextObjects { client, .. } => Some(client.as_str()),
+      Request::SelectTextObjects { client, .. } => Some(client.as_str()),
     }
   }
 }

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -67,10 +67,11 @@ pub enum Request {
     buffer: String,
     lang: String,
     timestamp: u64,
-    /// Which textobject to look for, i.e.  type,function,parameter,comment
+    /// Which textobject to look for, i.e. type,function,parameter,comment
     textobject_type: String,
-    /// Will return the smallest matching textobject that contains this selection
-    selection: kak::LocRange,
+    /// Space separated list of selections as kak::LocRange
+    /// For each selection, return the smallest matching textobject that contains this selection
+    selections: String,
     object_flags: kak::ObjectFlags,
     select_mode: kak::SelectMode,
   },

--- a/kak-tree-sitter/src/response.rs
+++ b/kak-tree-sitter/src/response.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use itertools::Itertools;
 
 use crate::highlighting::KakHighlightRange;
+use crate::kak;
 
 /// Response sent by the daemon to Kakoune.
 #[derive(Debug, Eq, PartialEq)]
@@ -37,6 +38,12 @@ pub enum Response {
   Highlights {
     timestamp: u64,
     ranges: Vec<KakHighlightRange>,
+  },
+
+  TextObject {
+    timestamp: u64,
+    obj_type: String,
+    range: kak::LocRange,
   },
 }
 
@@ -100,6 +107,14 @@ impl Response {
           "{range_specs} {timestamp} {ranges_str}",
           range_specs = "set buffer kts_highlighter_ranges",
         )
+      }
+
+      Response::TextObject {
+        timestamp,
+        obj_type,
+        range,
+      } => {
+        format!("select -timestamp {timestamp} {range}")
       }
     };
 

--- a/kak-tree-sitter/src/response.rs
+++ b/kak-tree-sitter/src/response.rs
@@ -40,10 +40,10 @@ pub enum Response {
     ranges: Vec<KakHighlightRange>,
   },
 
-  TextObject {
+  TextObjects {
     timestamp: u64,
     obj_type: String,
-    range: kak::LocRange,
+    ranges: Vec<kak::LocRange>,
   },
 }
 
@@ -109,12 +109,13 @@ impl Response {
         )
       }
 
-      Response::TextObject {
+      Response::TextObjects {
         timestamp,
-        obj_type,
-        range,
+        obj_type: _,
+        ranges,
       } => {
-        format!("select -timestamp {timestamp} {range}")
+        let ranges = ranges.iter().join(" ");
+        format!("select -timestamp {timestamp} {ranges}")
       }
     };
 

--- a/kak-tree-sitter/src/response.rs
+++ b/kak-tree-sitter/src/response.rs
@@ -40,9 +40,8 @@ pub enum Response {
     ranges: Vec<KakHighlightRange>,
   },
 
-  TextObjects {
+  Selections {
     timestamp: u64,
-    obj_type: String,
     ranges: Vec<kak::LocRange>,
   },
 }
@@ -109,13 +108,13 @@ impl Response {
         )
       }
 
-      Response::TextObjects {
-        timestamp,
-        obj_type: _,
-        ranges,
-      } => {
-        let ranges = ranges.iter().join(" ");
-        format!("select -timestamp {timestamp} {ranges}")
+      Response::Selections { timestamp, ranges } => {
+        if ranges.is_empty() {
+          "fail no selections remaining".into()
+        } else {
+          let ranges = ranges.iter().join(" ");
+          format!("select -timestamp {timestamp} {ranges}")
+        }
       }
     };
 

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -27,6 +27,7 @@ use crate::{
   cli::Cli,
   error::OhNo,
   handler::Handler,
+  kak,
   request::{Request, UnixRequest},
   response::{ConnectedResponse, Response},
   session::{Fifo, Session, SessionState, SessionTracker},
@@ -888,15 +889,42 @@ impl FifoHandler {
         timestamp,
         textobject_type,
         selection,
-      } => self.handler.handle_text_objects(
-        session.name(),
-        &buffer,
-        &lang,
-        timestamp,
-        buf,
-        selection,
-        textobject_type,
-      ),
+        object_flags,
+        select_mode,
+      } => {
+        let range = self.handler.handle_text_objects(
+          session.name(),
+          &buffer,
+          &lang,
+          timestamp,
+          buf,
+          &selection,
+          &textobject_type,
+          object_flags.inner,
+        )?;
+        if let Some(range) = range {
+          // Merge selections as specified
+          let mut out_sel = if object_flags.to_begin && object_flags.to_end {
+            range
+          } else if object_flags.to_end {
+            kak::LocRange::new(selection.start(), range.end())
+          } else if object_flags.to_begin {
+            kak::LocRange::new(selection.end(), range.start())
+          } else {
+            selection
+          };
+          if select_mode == kak::SelectMode::Extend {
+            out_sel = out_sel.extend(selection)
+          }
+          Ok(Response::TextObject {
+            timestamp,
+            obj_type: textobject_type,
+            range: out_sel,
+          })
+        } else {
+          Ok(Response::status("No textobject found"))
+        }
+      }
       _ => {
         // This is a programming error
         unreachable!(

--- a/kak-tree-sitter/src/session.rs
+++ b/kak-tree-sitter/src/session.rs
@@ -2,6 +2,8 @@ use std::{collections::HashMap, fs::File};
 
 use mio::Token;
 
+use crate::request::Request;
+
 /// Session tracker,
 ///
 /// Responsible for tracking sessions (by names) along with the associated command token and buffer token.
@@ -135,17 +137,25 @@ pub enum SessionState {
   /// The session is idle.
   Idle,
 
-  /// The session requested highlighting and we are waiting for the buffer content.
-  HighlightingWaiting {
-    client: String,
-    buffer: String,
-    lang: String,
-    timestamp: u64,
-  },
+  /// A request is waiting for the buffer content.
+  WaitingForBuf(Request),
 }
 
 impl SessionState {
   pub fn idle(&mut self) {
     *self = SessionState::Idle
+  }
+
+  /// If a request is waiting for the buffer content, take it, and reset the state to idle
+  pub fn take_waiting_req(&mut self) -> Option<Request> {
+    if let SessionState::WaitingForBuf(_req) = self {
+      let oldself = std::mem::replace(self, SessionState::Idle);
+      let SessionState::WaitingForBuf(req) = oldself else {
+        unreachable!()
+      };
+      Some(req)
+    } else {
+      None
+    }
   }
 }

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -1,0 +1,83 @@
+//! Tree-sitter state (i.e. highlighting, tree walking, etc.)
+
+use tree_sitter::{Language as TSLanguage, Parser, Query, QueryCursor};
+use tree_sitter_highlight::Highlighter;
+
+use crate::error::OhNo;
+use crate::highlighting::KakHighlightRange;
+use crate::languages::Language;
+use crate::languages::Languages;
+
+/// State around a tree.
+///
+/// A tree-sitter tree represents a parsed buffer in a given state. It can be walked with queries and updated.
+pub struct TreeState {
+  highlighter: Highlighter,
+  parser: Parser,
+  tree: tree_sitter::Tree,
+}
+
+impl TreeState {
+  pub fn new(lang: &Language) -> Result<Self, OhNo> {
+    let mut parser = Parser::new();
+    parser.set_language(lang.lang());
+    parser.set_timeout_micros(1000);
+
+    let highlighter = Highlighter::new();
+
+    let tree = parser.parse("", None).unwrap();
+
+    Ok(Self {
+      highlighter,
+      parser,
+      tree,
+    })
+  }
+
+  pub fn parser_mut(&mut self) -> &mut Parser {
+    // TODO: Can this be merged with the highlighters parser?
+    &mut self.parser
+  }
+
+  pub fn parser(&self) -> &Parser {
+    // TODO: Can this be merged with the highlighters parser?
+    &self.parser
+  }
+
+  pub fn lang(&self) -> TSLanguage {
+    self.parser.language().unwrap() // Is set in constructor
+  }
+
+  pub fn update(&mut self, buf: &str) -> Result<(), OhNo> {
+    self.tree = self
+      .parser
+      .parse(buf.as_bytes(), None)
+      .ok_or(OhNo::CannotParseBuffer)?;
+    Ok(())
+  }
+
+  pub fn highlight(
+    &mut self,
+    lang: &Language,
+    langs: &Languages,
+    source: &str,
+  ) -> Result<Vec<KakHighlightRange>, OhNo> {
+    // TODO: Merge this logic with the one parser
+    crate::highlighting::highlight(&mut self.highlighter, lang, langs, source)
+  }
+
+  pub fn tree(&self) -> &tree_sitter::Tree {
+    &self.tree
+  }
+
+  pub fn query<'a>(
+    &'a self,
+    cursor: &'a mut QueryCursor,
+    query: &'a Query,
+    code: &'a str,
+  ) -> impl Iterator<Item = &'a tree_sitter::QueryCapture<'a>> {
+    let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
+
+    captures.flat_map(|(qm, _size)| qm.captures)
+  }
+}


### PR DESCRIPTION
I know you're working on something yourself, so feel free to close this if you're not interested. But i thought i would resubmit it now that i rebased and removed the unnecessary refactors.

- Add basic text object query support
- Implement text object mappings
- textobjects: Support multiple selections. <a-a>f selects the functions around all cursors
- Implement kak-tree-sitter-req-select: Narrow selections to text objects (analogous to the `s` command in kakoune)

There is some discussion in #234 on how the mappings should be done. Currently, this adds some mappings into the special kakoune `object` mode, used by `<a-i>`, `<a-a>`, `]` etc. Using the special object mode however, also gives us a lot of flexibility for free, so to me it seems worth considering

The "narrowing" selection is then currently mapped in a `kak-tree-sitter` user-mode, but the details of that UX seems like something worth discussing further

It all works with multiple selections and uses no shell calls. This means it does a lot of parsing of kakoune `%val{}` expansions in rust, but that seems reasonable.