### PR TITLE
[RFC] Autodetect highlighting groups from kakoune faces

### DIFF
--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -244,3 +244,16 @@ set-face global ts_variable_builtin             "%opt{kts_red}"
 set-face global ts_variable_other_member        "%opt{kts_teal}"
 set-face global ts_variable_parameter           "%opt{kts_maroon}+i"
 set-face global ts_warning                      "%opt{kts_peach}+b"
+
+define-command kak-tree-sitter-highlight-submit-faces %{
+  # Writes the names of all current faces in a specific format to the *debug* buffer
+  debug faces
+  eval -draft -save-regs "a" -no-hooks %{
+    eval -draft -buffer *debug* %{
+      # Long kakoune magic select all of the faces from the debug buffer that start with ts_
+      exec 'gj<a-/>^Faces:$<ret>?^[^ ]<ret>s^ \* ts_\w+:<ret>h<a-i>w'
+      set-register a "%val{selections}"
+    }
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""declare_faces"", ""faces"": ""%reg[a]"" }"
+  }
+}

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -88,4 +88,11 @@ impl Handler {
       )))
     }
   }
+
+  pub fn handle_declare_faces(&mut self, hl_names: Vec<String>) {
+    log::debug!("Active highlighter groups: {hl_names:?}");
+    for (_, lang) in self.langs.langs.iter_mut() {
+      lang.configure_hl_names(hl_names.clone())
+    }
+  }
 }

--- a/kak-tree-sitter/src/languages.rs
+++ b/kak-tree-sitter/src/languages.rs
@@ -21,9 +21,20 @@ pub struct Language {
   _ts_lib: libloading::Library,
 }
 
+impl Language {
+  pub fn lang(&self) -> tree_sitter::Language {
+    self.ts_lang
+  }
+  
+  pub fn configure_hl_names(&mut self, hl_names: Vec<String>) {
+     self.hl_config.configure(&hl_names);
+     self.hl_names = hl_names;
+  }
+}
+
 pub struct Languages {
   /// Map a `kts_lang` to the tree-sitter [`Language`] and its queries.
-  langs: HashMap<String, Language>,
+  pub langs: HashMap<String, Language>,
 }
 
 impl Languages {

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -59,6 +59,13 @@ pub enum Request {
     lang: String,
     timestamp: u64,
   },
+
+  /// Set which faces are available for highlighting
+  /// This is the list of faces from kakoune that need to be parsed to choose the available selectors
+  DeclareFaces {
+    /// Space separated list of face names formatted as ts_<selector>_<subselector>
+    faces: String,
+  },
 }
 
 impl Request {
@@ -66,6 +73,7 @@ impl Request {
     match self {
       Request::TryEnableHighlight { client, .. } => Some(client.as_str()),
       Request::Highlight { client, .. } => Some(client.as_str()),
+      Request::DeclareFaces { .. } => None,
     }
   }
 }

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -819,6 +819,15 @@ impl FifoHandler {
 
         Ok(None)
       }
+      Request::DeclareFaces { faces } => {
+        let hl_names: Vec<_> = faces
+          .split_whitespace()
+          .filter_map(|x| Some(x.strip_prefix("ts_")?.replace('_', ".").replace("..", "_")))
+          .collect();
+          
+        self.handler.handle_declare_faces(hl_names);
+        Ok(None)
+      }
     }
   }
 


### PR DESCRIPTION
This is a slightly hacky way to do it, but it gets the list of available faces from kakoune, and uses it to compute the list of highlighting groups. This means the `highlihgt.groups` option could be removed from the config, so at least themes that are kts aware, can specify which faces they support.

I dont think this is necessarily a good way to do it, and im not sure its even something we want to do, but i found the methodology interesting, hence the RFC tag.

If we did decide to go this route, i would try to get `debug -to-file` implemented in kakoune, so we dont have to fill up the `*debug*` buffer and parse from there.