### PR TITLE
Support text-objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "thiserror",
  "tree-sitter",
  "tree-sitter-highlight",
+ "tree-sitter-rust",
  "unicode-segmentation",
 ]
 
@@ -608,6 +609,16 @@ checksum = "042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc"
 dependencies = [
  "regex",
  "thiserror",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+dependencies = [
+ "cc",
  "tree-sitter",
 ]
 

--- a/kak-tree-sitter/Cargo.toml
+++ b/kak-tree-sitter/Cargo.toml
@@ -30,3 +30,6 @@ thiserror = "1.0.57"
 tree-sitter = "0.20.10"
 tree-sitter-highlight = "0.20.1"
 unicode-segmentation = "1.11.0"
+
+[dev-dependencies]
+tree-sitter-rust = "0.20.4"

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -94,6 +94,14 @@ define-command kak-tree-sitter-req-highlight-buffer -docstring 'Highlight the cu
   }
 }
 
+# Send a single request to modify selections with text-objects.
+define-command kak-tree-sitter-req-text-objects -params 2 %{
+  evaluate-commands -no-hooks %{
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""pattern"": ""%arg{1}"", ""selections"": ""%val{selections_desc}"", ""mode"": ""%arg{2}"" }"
+    write %opt{kts_buf_fifo_path}
+  }
+}
+
 # Enable highlighting for the current buffer.
 # 
 # This command does a couple of things, among removing the « default » highlighting (Kakoune based) of the buffer and

--- a/kak-tree-sitter/rc/text-objects.kak
+++ b/kak-tree-sitter/rc/text-objects.kak
@@ -57,3 +57,8 @@ map global tree-sitter-find-extend-rev f ':kak-tree-sitter-req-text-objects func
 map global tree-sitter-find-extend-rev a ':kak-tree-sitter-req-text-objects parameter.around extend_prev<ret>' -docstring 'parameter'
 map global tree-sitter-find-extend-rev t ':kak-tree-sitter-req-text-objects class.around extend_prev<ret>' -docstring 'class'
 map global tree-sitter-find-extend-rev T ':kak-tree-sitter-req-text-objects test.around extend_prev<ret>' -docstring 'test'
+
+map global object f '<a-;>kak-tree-sitter-req-object-text-objects function<ret>' -docstring 'function (tree-sitter)'
+map global object t '<a-;>kak-tree-sitter-req-object-text-objects class<ret>' -docstring 'type (tree-sitter)'
+map global object a '<a-;>kak-tree-sitter-req-object-text-objects parameter<ret>' -docstring 'argument (tree-sitter)'
+map global object T '<a-;>kak-tree-sitter-req-object-text-objects test<ret>' -docstring 'test (tree-sitter)'

--- a/kak-tree-sitter/rc/text-objects.kak
+++ b/kak-tree-sitter/rc/text-objects.kak
@@ -1,0 +1,59 @@
+declare-user-mode tree-sitter
+declare-user-mode tree-sitter-search
+declare-user-mode tree-sitter-search-rev
+declare-user-mode tree-sitter-search-extend
+declare-user-mode tree-sitter-search-extend-rev
+declare-user-mode tree-sitter-find
+declare-user-mode tree-sitter-find-rev
+declare-user-mode tree-sitter-find-extend
+declare-user-mode tree-sitter-find-extend-rev
+
+map global tree-sitter /     ':enter-user-mode tree-sitter-search<ret>'            -docstring 'search next'
+map global tree-sitter <a-/> ':enter-user-mode tree-sitter-search-rev<ret>'        -docstring 'search prev'
+map global tree-sitter ?     ':enter-user-mode tree-sitter-search-extend<ret>'     -docstring 'search(extend) next'
+map global tree-sitter <a-?> ':enter-user-mode tree-sitter-search-extend-rev<ret>' -docstring 'search(extend) prev'
+map global tree-sitter f     ':enter-user-mode tree-sitter-find<ret>'              -docstring 'find next'
+map global tree-sitter <a-f> ':enter-user-mode tree-sitter-find-rev<ret>'          -docstring 'find prev'
+map global tree-sitter F     ':enter-user-mode tree-sitter-find-extend<ret>'       -docstring 'find(extend) next'
+map global tree-sitter <a-F> ':enter-user-mode tree-sitter-find-extend-rev<ret>'   -docstring 'find(extend) prev'
+
+map global tree-sitter-search f ':kak-tree-sitter-req-text-objects function.around search_next<ret>'  -docstring 'function'
+map global tree-sitter-search a ':kak-tree-sitter-req-text-objects parameter.around search_next<ret>' -docstring 'parameter'
+map global tree-sitter-search t ':kak-tree-sitter-req-text-objects class.around search_next<ret>' -docstring 'class'
+map global tree-sitter-search c ':kak-tree-sitter-req-text-objects comment.around search_next<ret>' -docstring 'comment'
+map global tree-sitter-search T ':kak-tree-sitter-req-text-objects test.around search_next<ret>' -docstring 'test'
+
+map global tree-sitter-search-rev f ':kak-tree-sitter-req-text-objects function.around search_prev<ret>'  -docstring 'function'
+map global tree-sitter-search-rev a ':kak-tree-sitter-req-text-objects parameter.around search_prev<ret>' -docstring 'parameter'
+map global tree-sitter-search-rev t ':kak-tree-sitter-req-text-objects class.around search_prev<ret>' -docstring 'class'
+map global tree-sitter-search-rev T ':kak-tree-sitter-req-text-objects test.around search_prev<ret>' -docstring 'test'
+
+map global tree-sitter-search-extend f ':kak-tree-sitter-req-text-objects function.around search_extend_next<ret>'  -docstring 'function'
+map global tree-sitter-search-extend a ':kak-tree-sitter-req-text-objects parameter.around search_extend_next<ret>' -docstring 'parameter'
+map global tree-sitter-search-extend t ':kak-tree-sitter-req-text-objects class.around search_extend_next<ret>' -docstring 'class'
+map global tree-sitter-search-extend T ':kak-tree-sitter-req-text-objects test.around search_extend_next<ret>' -docstring 'test'
+
+map global tree-sitter-search-extend-rev f ':kak-tree-sitter-req-text-objects function.around search_extend_prev<ret>'  -docstring 'function'
+map global tree-sitter-search-extend-rev a ':kak-tree-sitter-req-text-objects parameter.around search_extend_prev<ret>' -docstring 'parameter'
+map global tree-sitter-search-extend-rev t ':kak-tree-sitter-req-text-objects class.around search_extend_prev<ret>' -docstring 'class'
+map global tree-sitter-search-extend-rev T ':kak-tree-sitter-req-text-objects test.around search_extend_prev<ret>' -docstring 'test'
+
+map global tree-sitter-find f ':kak-tree-sitter-req-text-objects function.around find_next<ret>'  -docstring 'function'
+map global tree-sitter-find a ':kak-tree-sitter-req-text-objects parameter.around find_next<ret>' -docstring 'parameter'
+map global tree-sitter-find t ':kak-tree-sitter-req-text-objects class.around find_next<ret>' -docstring 'class'
+map global tree-sitter-find T ':kak-tree-sitter-req-text-objects test.around find_next<ret>' -docstring 'test'
+
+map global tree-sitter-find-rev f ':kak-tree-sitter-req-text-objects function.around find_prev<ret>'  -docstring 'function'
+map global tree-sitter-find-rev a ':kak-tree-sitter-req-text-objects parameter.around find_prev<ret>' -docstring 'parameter'
+map global tree-sitter-find-rev t ':kak-tree-sitter-req-text-objects class.around find_prev<ret>' -docstring 'class'
+map global tree-sitter-find-rev T ':kak-tree-sitter-req-text-objects test.around find_prev<ret>' -docstring 'test'
+
+map global tree-sitter-find-extend f ':kak-tree-sitter-req-text-objects function.around extend_next<ret>'  -docstring 'function'
+map global tree-sitter-find-extend a ':kak-tree-sitter-req-text-objects parameter.around extend_next<ret>' -docstring 'parameter'
+map global tree-sitter-find-extend t ':kak-tree-sitter-req-text-objects class.around extend_next<ret>' -docstring 'class'
+map global tree-sitter-find-extend T ':kak-tree-sitter-req-text-objects test.around extend_next<ret>' -docstring 'test'
+
+map global tree-sitter-find-extend-rev f ':kak-tree-sitter-req-text-objects function.around extend_prev<ret>'  -docstring 'function'
+map global tree-sitter-find-extend-rev a ':kak-tree-sitter-req-text-objects parameter.around extend_prev<ret>' -docstring 'parameter'
+map global tree-sitter-find-extend-rev t ':kak-tree-sitter-req-text-objects class.around extend_prev<ret>' -docstring 'class'
+map global tree-sitter-find-extend-rev T ':kak-tree-sitter-req-text-objects test.around extend_prev<ret>' -docstring 'test'

--- a/kak-tree-sitter/src/buffer.rs
+++ b/kak-tree-sitter/src/buffer.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+/// A unique way to identify a buffer.
+///
+/// Currently tagged by the session name and the buffer name.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct BufferId {
+  session: String,
+  buffer: String,
+}
+
+impl BufferId {
+  pub fn new(session: impl Into<String>, buffer: impl Into<String>) -> Self {
+    Self {
+      session: session.into(),
+      buffer: buffer.into(),
+    }
+  }
+}

--- a/kak-tree-sitter/src/cli.rs
+++ b/kak-tree-sitter/src/cli.rs
@@ -40,4 +40,13 @@ pub struct Cli {
   /// for trace logs.
   #[arg(short, long, action = clap::ArgAction::Count)]
   pub verbose: u8,
+
+  /// Insert Kakoune commands, user modes and mappings related to text-objects.
+  ///
+  /// Those are default and completely optional. It is advised to start with those and if further customization is
+  /// needed, you shall not use this flag and craft your own user modes and mappings.
+  ///
+  /// Text-objects user-modes will be available via the 'tree-sitter' user-mode.
+  #[arg(long)]
+  pub with_text_objects: bool,
 }

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -89,6 +89,9 @@ pub enum OhNo {
   #[error("text-objects not supported")]
   UnsupportedTextObjects,
 
-  #[error("no such {ty} text-object query")]
-  UnknownTextObjectQuery { ty: text_objects::Type },
+  #[error("no such {pattern}.{level} text-object query")]
+  UnknownTextObjectQuery {
+    pattern: String,
+    level: text_objects::Level,
+  },
 }

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -2,7 +2,9 @@ use std::{io, path::PathBuf};
 
 use log::SetLoggerError;
 use thiserror::Error;
-use tree_sitter::LanguageError;
+use tree_sitter::{LanguageError, QueryError};
+
+use crate::text_objects;
 
 #[derive(Debug, Error)]
 pub enum OhNo {
@@ -77,4 +79,16 @@ pub enum OhNo {
     #[from]
     err: LanguageError,
   },
+
+  #[error("query error: {err}")]
+  QueryError {
+    #[from]
+    err: QueryError,
+  },
+
+  #[error("text-objects not supported")]
+  UnsupportedTextObjects,
+
+  #[error("no such {ty} text-object query")]
+  UnknownTextObjectQuery { ty: text_objects::Type },
 }

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -2,6 +2,7 @@ use std::{io, path::PathBuf};
 
 use log::SetLoggerError;
 use thiserror::Error;
+use tree_sitter::LanguageError;
 
 #[derive(Debug, Error)]
 pub enum OhNo {
@@ -65,6 +66,15 @@ pub enum OhNo {
   #[error("cannot send request: {err}")]
   CannotSendRequest { err: String },
 
+  #[error("cannot parse buffer")]
+  CannotParseBuffer,
+
   #[error("highlight error: {err}")]
   HighlightError { err: String },
+
+  #[error("language error: {err}")]
+  LangError {
+    #[from]
+    err: LanguageError,
+  },
 }

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -4,8 +4,6 @@ use log::SetLoggerError;
 use thiserror::Error;
 use tree_sitter::{LanguageError, QueryError};
 
-use crate::text_objects;
-
 #[derive(Debug, Error)]
 pub enum OhNo {
   #[error("nothing to do; please either use --server or --request")]
@@ -89,9 +87,6 @@ pub enum OhNo {
   #[error("text-objects not supported")]
   UnsupportedTextObjects,
 
-  #[error("no such {pattern}.{level} text-object query")]
-  UnknownTextObjectQuery {
-    pattern: String,
-    level: text_objects::Level,
-  },
+  #[error("no such {pattern} text-object query")]
+  UnknownTextObjectQuery { pattern: String },
 }

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 use kak_tree_sitter_config::Config;
+use tree_sitter::Language;
 
 use crate::{
   error::OhNo,
@@ -37,6 +38,29 @@ impl Handler {
       trees,
       langs,
     })
+  }
+
+  /// Ensure we have a parsed tree for this buffer id and buffer content.
+  fn compute_tree<'a>(
+    tree_states: &'a mut HashMap<BufferId, TreeState>,
+    lang: Language,
+    buffer_id: BufferId,
+    buf: &str,
+  ) -> Result<&'a mut TreeState, OhNo> {
+    match tree_states.entry(buffer_id) {
+      Entry::Vacant(entry) => {
+        // first time we see this buffer; full parse
+        let tree_state = TreeState::new(lang, buf)?;
+        Ok(entry.insert(tree_state))
+      }
+
+      Entry::Occupied(mut entry) => {
+        // TODO(#26): we already have a parsed buffer; we want an incremental update instead of fully reparsing everything
+        let tree_state = TreeState::new(lang, buf)?;
+        entry.insert(tree_state);
+        Ok(entry.into_mut())
+      }
+    }
   }
 
   pub fn handle_try_enable_highlight(
@@ -88,14 +112,17 @@ impl Handler {
     buf: &str,
   ) -> Result<Response, OhNo> {
     if let Some(lang) = self.langs.get(lang_name) {
-      // HACK: current test with the new tree-sitter implementation
-      if let Some(tree) = self.trees.get_mut(&buffer_id) {
-        tree.query(&lang.hl_config.query, buf);
-      }
+      // HACK: current test with the new tree-sitter implementation; actually, I think we shouldn’t do that here; we
+      // should require the buffer to be parsed in the first place
+      let tree_state = Self::compute_tree(&mut self.trees, lang.lang(), buffer_id, buf)?;
 
-      self
-        .highlighters
-        .highlight(lang, &self.langs, buffer_id, timestamp, buf)
+      tree_state.query(&lang.hl_config.query, buf);
+      log::info!("trying injections now…");
+      Ok(Response::status("unimplemented"))
+
+      //self
+      //  .highlighters
+      //  .highlight(lang, &self.langs, buffer_id, timestamp, buf)
     } else {
       Ok(Response::status(format!(
         "unsupported language: {lang_name}"

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use kak_tree_sitter_config::Config;
 
 use crate::{
@@ -5,6 +7,7 @@ use crate::{
   highlighting::{BufferId, Highlighters},
   languages::Languages,
   response::Response,
+  tree_sitter_state::TreeState,
 };
 
 /// Type responsible for handling requests.
@@ -12,8 +15,12 @@ use crate::{
 /// This type is stateful, as requests might have side-effect (i.e. tree-sitter parsing generates trees/highlighters
 /// that can be reused, for instance).
 pub struct Handler {
+  // TODO: should be removed and moved into `trees`
   /// Map a highlighter to a [`BufferId`].
   highlighters: Highlighters,
+
+  /// Tree-sitter trees associated with a [`BufferId`].
+  trees: HashMap<BufferId, TreeState>,
 
   /// Known languages.
   langs: Languages,
@@ -22,10 +29,12 @@ pub struct Handler {
 impl Handler {
   pub fn new(config: &Config) -> Result<Self, OhNo> {
     let highlighters = Highlighters::new();
+    let trees = HashMap::default();
     let langs = Languages::load_from_dir(config)?;
 
     Ok(Self {
       highlighters,
+      trees,
       langs,
     })
   }
@@ -79,6 +88,11 @@ impl Handler {
     buf: &str,
   ) -> Result<Response, OhNo> {
     if let Some(lang) = self.langs.get(lang_name) {
+      // HACK: current test with the new tree-sitter implementation
+      if let Some(tree) = self.trees.get_mut(&buffer_id) {
+        tree.query(&lang.hl_config.query, buf);
+      }
+
       self
         .highlighters
         .highlight(lang, &self.langs, buffer_id, timestamp, buf)

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -3,8 +3,8 @@ use std::collections::{hash_map::Entry, HashMap};
 use kak_tree_sitter_config::Config;
 
 use crate::{
+  buffer::BufferId,
   error::OhNo,
-  highlighting::BufferId,
   languages::{Language, Languages},
   response::Response,
   selection::Sel,

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -153,8 +153,8 @@ impl Handler {
     };
 
     let tree_state = Self::compute_tree(&mut self.trees, lang, buffer_id, buf)?;
-    tree_state.text_objects(lang, buf, pattern, selections, mode)?;
+    let sels = tree_state.text_objects(lang, buf, pattern, selections, mode)?;
 
-    Ok(Response::status("done"))
+    Ok(Response::Selections { sels })
   }
 }

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,12 +1,11 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use kak_tree_sitter_config::Config;
-use tree_sitter::Language;
 
 use crate::{
   error::OhNo,
-  highlighting::{BufferId, Highlighters},
-  languages::Languages,
+  highlighting::BufferId,
+  languages::{Language, Languages},
   response::Response,
   tree_sitter_state::TreeState,
 };
@@ -16,10 +15,6 @@ use crate::{
 /// This type is stateful, as requests might have side-effect (i.e. tree-sitter parsing generates trees/highlighters
 /// that can be reused, for instance).
 pub struct Handler {
-  // TODO: should be removed and moved into `trees`
-  /// Map a highlighter to a [`BufferId`].
-  highlighters: Highlighters,
-
   /// Tree-sitter trees associated with a [`BufferId`].
   trees: HashMap<BufferId, TreeState>,
 
@@ -29,25 +24,20 @@ pub struct Handler {
 
 impl Handler {
   pub fn new(config: &Config) -> Result<Self, OhNo> {
-    let highlighters = Highlighters::new();
     let trees = HashMap::default();
     let langs = Languages::load_from_dir(config)?;
 
-    Ok(Self {
-      highlighters,
-      trees,
-      langs,
-    })
+    Ok(Self { trees, langs })
   }
 
   /// Ensure we have a parsed tree for this buffer id and buffer content.
   fn compute_tree<'a>(
-    tree_states: &'a mut HashMap<BufferId, TreeState>,
-    lang: Language,
+    trees: &'a mut HashMap<BufferId, TreeState>,
+    lang: &Language,
     buffer_id: BufferId,
     buf: &str,
   ) -> Result<&'a mut TreeState, OhNo> {
-    match tree_states.entry(buffer_id) {
+    match trees.entry(buffer_id) {
       Entry::Vacant(entry) => {
         // first time we see this buffer; full parse
         let tree_state = TreeState::new(lang, buf)?;
@@ -112,17 +102,13 @@ impl Handler {
     buf: &str,
   ) -> Result<Response, OhNo> {
     if let Some(lang) = self.langs.get(lang_name) {
-      // HACK: current test with the new tree-sitter implementation; actually, I think we shouldn’t do that here; we
-      // should require the buffer to be parsed in the first place
-      let tree_state = Self::compute_tree(&mut self.trees, lang.lang(), buffer_id, buf)?;
+      let tree_state = Self::compute_tree(&mut self.trees, lang, buffer_id, buf)?;
 
-      tree_state.query(&lang.hl_config.query, buf);
-      log::info!("trying injections now…");
-      Ok(Response::status("unimplemented"))
+      let ranges = tree_state.highlight(lang, buf, |lang2| {
+        self.langs.get(lang2).map(|lang2| &lang2.hl_config)
+      })?;
 
-      //self
-      //  .highlighters
-      //  .highlight(lang, &self.langs, buffer_id, timestamp, buf)
+      Ok(Response::Highlights { timestamp, ranges })
     } else {
       Ok(Response::status(format!(
         "unsupported language: {lang_name}"

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -82,27 +82,13 @@ impl Handler {
 
   pub fn handle_highlight(
     &mut self,
-    session_name: &str,
-    buffer: &str,
-    lang_name: &str,
-    timestamp: u64,
-    buf: &str,
-  ) -> Result<Response, OhNo> {
-    log::debug!(
-      "highlight for session {session_name}, buffer {buffer}, lang {lang_name}, timestamp {timestamp}"
-    );
-
-    let buffer_id = BufferId::new(session_name, buffer);
-    self.handle_highlight_req(buffer_id, lang_name, timestamp, buf)
-  }
-
-  fn handle_highlight_req(
-    &mut self,
     buffer_id: BufferId,
     lang_name: &str,
     timestamp: u64,
     buf: &str,
   ) -> Result<Response, OhNo> {
+    log::debug!("highlight for buffer {buffer_id:?}, lang {lang_name}, timestamp {timestamp}");
+
     let Some(lang) = self.langs.get(lang_name) else {
       return Ok(Response::status(format!(
         "unsupported language: {lang_name}"
@@ -120,25 +106,6 @@ impl Handler {
 
   pub fn handle_text_objects(
     &mut self,
-    session_name: &str,
-    buffer: &str,
-    lang_name: &str,
-    buf: &str,
-    pattern: &str,
-    selections: &[Sel],
-    mode: &text_objects::OperationMode,
-  ) -> Result<Response, OhNo> {
-    log::debug!(
-      "text-objects {pattern} for session {session_name}, buffer {buffer}, lang {lang_name}"
-    );
-
-    let buffer_id = BufferId::new(session_name, buffer);
-
-    self.handle_text_objects_req(buffer_id, lang_name, buf, pattern, selections, mode)
-  }
-
-  fn handle_text_objects_req(
-    &mut self,
     buffer_id: BufferId,
     lang_name: &str,
     buf: &str,
@@ -146,6 +113,8 @@ impl Handler {
     selections: &[Sel],
     mode: &text_objects::OperationMode,
   ) -> Result<Response, OhNo> {
+    log::debug!("text-objects {pattern} for buffer {buffer_id:?}, lang {lang_name}");
+
     let Some(lang) = self.langs.get(lang_name) else {
       return Ok(Response::status(format!(
         "unsupported language: {lang_name}"

--- a/kak-tree-sitter/src/highlighting.rs
+++ b/kak-tree-sitter/src/highlighting.rs
@@ -231,6 +231,7 @@ where
 
 #[cfg(test)]
 mod tests {
+  use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
   use unicode_segmentation::UnicodeSegmentation;
 
   use super::ByteLineColMapper;
@@ -345,5 +346,113 @@ mod tests {
     mapper.advance(3);
     assert_eq!(mapper.line(), 2);
     assert_eq!(mapper.col_byte(), 0);
+  }
+
+  #[test]
+  fn kak_hl_ranges_from_iter() {
+    let source = "fn foo(a: i32, b: /* ® */ impl Into<Option<String>>) {}";
+    let hl_names = vec![
+      "constant",
+      "function",
+      "keyword",
+      "variable",
+      "punctuation",
+      "type",
+      "comment",
+    ];
+
+    let mut hl_conf = HighlightConfiguration::new(
+      tree_sitter_rust::language(),
+      tree_sitter_rust::HIGHLIGHT_QUERY,
+      tree_sitter_rust::INJECTIONS_QUERY,
+      "",
+    )
+    .unwrap();
+    hl_conf.configure(&hl_names);
+
+    let mut hl = Highlighter::new();
+    let events: Vec<_> = hl
+      .highlight(&hl_conf, source.as_bytes(), None, |_| None)
+      .unwrap()
+      .flatten()
+      .collect();
+
+    assert_eq!(events.len(), 70);
+
+    assert!(matches!(
+      events[..],
+      [
+        HighlightEvent::HighlightStart(Highlight(2)),
+        HighlightEvent::Source { start: 0, end: 2 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 2, end: 3 },
+        HighlightEvent::HighlightStart(Highlight(1)),
+        HighlightEvent::Source { start: 3, end: 6 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 6, end: 7 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(3)),
+        HighlightEvent::Source { start: 7, end: 8 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 8, end: 9 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 9, end: 10 },
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 10, end: 13 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 13, end: 14 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 14, end: 15 },
+        HighlightEvent::HighlightStart(Highlight(3)),
+        HighlightEvent::Source { start: 15, end: 16 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 16, end: 17 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 17, end: 18 },
+        HighlightEvent::HighlightStart(Highlight(6)),
+        HighlightEvent::Source { start: 18, end: 26 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 26, end: 27 },
+        HighlightEvent::HighlightStart(Highlight(2)),
+        HighlightEvent::Source { start: 27, end: 31 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 31, end: 32 },
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 32, end: 36 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 36, end: 37 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 37, end: 43 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 43, end: 44 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 44, end: 50 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 50, end: 51 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 51, end: 52 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 52, end: 53 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 53, end: 54 },
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 54, end: 55 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 55, end: 56 },
+        HighlightEvent::HighlightEnd
+      ]
+    ));
   }
 }

--- a/kak-tree-sitter/src/highlighting.rs
+++ b/kak-tree-sitter/src/highlighting.rs
@@ -1,6 +1,5 @@
 //! Convert from tree-sitter-highlight events to Kakoune ranges highlighter.
 
-use serde::{Deserialize, Serialize};
 use tree_sitter_highlight::{Highlight, HighlightEvent};
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/kak-tree-sitter/src/highlighting.rs
+++ b/kak-tree-sitter/src/highlighting.rs
@@ -12,23 +12,6 @@ use crate::{
   response::Response,
 };
 
-/// A unique way to identify a buffer.
-///
-/// Currently tagged by the session name and the buffer name.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct BufferId {
-  session: String,
-  buffer: String,
-}
-
-impl BufferId {
-  pub fn new(session: impl Into<String>, buffer: impl Into<String>) -> Self {
-    Self {
-      session: session.into(),
-      buffer: buffer.into(),
-    }
-  }
-}
 
 /// Session/buffer highlighters.
 ///

--- a/kak-tree-sitter/src/languages.rs
+++ b/kak-tree-sitter/src/languages.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, path::Path};
 
 use kak_tree_sitter_config::{Config, LanguagesConfig};
 use libloading::Symbol;
+use tree_sitter::Query;
 use tree_sitter_highlight::HighlightConfiguration;
 
 use crate::{error::OhNo, queries::Queries};
@@ -15,6 +16,8 @@ pub struct Language {
   pub hl_names: Vec<String>,
   // whether we should remove the default highlighter when highlighting a buffer with this language
   pub remove_default_highlighter: bool,
+  // query to use for text objects, if supported by the language
+  pub textobject_query: Option<Query>,
 
   // NOTE: we need to keep that alive *probably*; better be safe than sorry
   ts_lang: tree_sitter::Language,
@@ -96,10 +99,17 @@ impl Languages {
 
           let remove_default_highlighter = lang_config.remove_default_highlighter.to_bool();
 
+          let textobject_query = queries
+            .text_objects
+            .as_deref()
+            .map(|q| Query::new(ts_lang, q).map(Some))
+            .unwrap_or_else(|| Ok(None))?;
+
           let lang = Language {
             hl_config,
             hl_names,
             remove_default_highlighter,
+            textobject_query,
             ts_lang,
             _ts_lib: ts_lib,
           };

--- a/kak-tree-sitter/src/languages.rs
+++ b/kak-tree-sitter/src/languages.rs
@@ -17,8 +17,14 @@ pub struct Language {
   pub remove_default_highlighter: bool,
 
   // NOTE: we need to keep that alive *probably*; better be safe than sorry
-  _ts_lang: tree_sitter::Language,
+  ts_lang: tree_sitter::Language,
   _ts_lib: libloading::Library,
+}
+
+impl Language {
+  pub fn lang(&self) -> tree_sitter::Language {
+    self.ts_lang
+  }
 }
 
 pub struct Languages {
@@ -94,7 +100,7 @@ impl Languages {
             hl_config,
             hl_names,
             remove_default_highlighter,
-            _ts_lang: ts_lang,
+            ts_lang,
             _ts_lib: ts_lib,
           };
           langs.insert(lang_name.to_owned(), lang);

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -10,6 +10,7 @@ mod request;
 mod response;
 mod server;
 mod session;
+mod text_objects;
 mod tree_sitter_state;
 
 use clap::Parser;

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -10,6 +10,7 @@ mod request;
 mod response;
 mod server;
 mod session;
+mod tree_sitter_state;
 
 use clap::Parser;
 use cli::Cli;

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -1,3 +1,4 @@
+mod buffer;
 mod cli;
 mod error;
 mod handler;

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -8,6 +8,7 @@ mod queries;
 mod rc;
 mod request;
 mod response;
+mod selection;
 mod server;
 mod session;
 mod text_objects;

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -45,6 +45,11 @@ fn start() -> Result<(), OhNo> {
     println!("{}", rc::static_kak());
   }
 
+  // inject a default text-object setup if requested
+  if cli.with_text_objects {
+    println!("{}", rc::text_objects_kak());
+  }
+
   // server logic implies short-circuiting the rest; hence why we have to pass it &cli to check some stuff once the
   // server is started, like whether we started from Kakoune / the session name / etc.
   if cli.server {

--- a/kak-tree-sitter/src/queries.rs
+++ b/kak-tree-sitter/src/queries.rs
@@ -17,7 +17,7 @@ impl Queries {
     let highlights = fs::read_to_string(dir.join("highlights.scm")).ok();
     let injections = fs::read_to_string(dir.join("injections.scm")).ok();
     let locals = fs::read_to_string(dir.join("locals.scm")).ok();
-    let text_objects = fs::read_to_string(dir.join("text_objects.scm")).ok();
+    let text_objects = fs::read_to_string(dir.join("textobjects.scm")).ok();
 
     Queries {
       highlights,

--- a/kak-tree-sitter/src/rc.rs
+++ b/kak-tree-sitter/src/rc.rs
@@ -1,5 +1,11 @@
 //! rc file used by Kakoune to inject kak-tree-sitter commands.
 
+/// Main RC file.
 pub fn static_kak() -> &'static str {
   include_str!("../rc/static.kak")
+}
+
+/// Text-objects related file.
+pub fn text_objects_kak() -> &'static str {
+  include_str!("../rc/text-objects.kak")
 }

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
+use crate::text_objects;
+
 /// Unidentified request (i.e. not linked to a given session).
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -59,6 +61,16 @@ pub enum Request {
     lang: String,
     timestamp: u64,
   },
+
+  /// TODO
+  TextObjects {
+    client: String,
+    buffer: String,
+    lang: String,
+    pattern: String,
+    selections: String,
+    mode: text_objects::OperationMode,
+  },
 }
 
 impl Request {
@@ -66,6 +78,7 @@ impl Request {
     match self {
       Request::TryEnableHighlight { client, .. } => Some(client.as_str()),
       Request::Highlight { client, .. } => Some(client.as_str()),
+      Request::TextObjects { client, .. } => Some(client.as_str()),
     }
   }
 }

--- a/kak-tree-sitter/src/response.rs
+++ b/kak-tree-sitter/src/response.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use itertools::Itertools;
 
-use crate::highlighting::KakHighlightRange;
+use crate::{highlighting::KakHighlightRange, selection::Sel};
 
 /// Response sent by the daemon to Kakoune.
 #[derive(Debug, Eq, PartialEq)]
@@ -38,6 +38,11 @@ pub enum Response {
     timestamp: u64,
     ranges: Vec<KakHighlightRange>,
   },
+
+  /// Selections.
+  ///
+  /// These selections are typically returned when the user asked to perform text-objects queries.
+  Selections { sels: Vec<Sel> },
 }
 
 impl Response {
@@ -100,6 +105,11 @@ impl Response {
           "{range_specs} {timestamp} {ranges_str}",
           range_specs = "set buffer kts_highlighter_ranges",
         )
+      }
+
+      Response::Selections { sels } => {
+        let sels_str = sels.iter().map(|sel| sel.to_kak_str()).join(" ");
+        format!("select {sels_str}")
       }
     };
 

--- a/kak-tree-sitter/src/selection.rs
+++ b/kak-tree-sitter/src/selection.rs
@@ -1,0 +1,162 @@
+//! Selections as recognized by Kakoune, as well as associated types and functions.
+
+/// A single position in a buffer.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Pos {
+  pub line: usize,
+  pub col: usize,
+}
+
+impl Pos {
+  /// Read a [`Pos`] from Kakoune-formatted string; i.e. <line>.<col>.
+  ///
+  /// Return [`None`] if parsing failed.
+  pub fn parse_kak_str(s: &str) -> Option<Self> {
+    let mut parts = s.split('.').flat_map(|s| s.parse().ok());
+    let line = parts.next()?;
+    let col = parts.next()?;
+
+    Some(Self { line, col })
+  }
+}
+
+/// A single selection, containing an anchor and a cursor.
+///
+/// Note: there is no rule about anchors and cursors. One can come before the other; do not assume anything about their
+/// position.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Sel {
+  pub anchor: Pos,
+  pub cursor: Pos,
+}
+
+impl Sel {
+  /// Read a [`Sel`] from Kakoune-formatted string; i.e. <anchor_line>.<anchor_col>,<cursor_line>.<cursor_col>.
+  ///
+  /// Return [`None`] if parsing failed.
+  pub fn parse_kak_str(s: &str) -> Option<Self> {
+    let mut parts = s.split(',').flat_map(Pos::parse_kak_str);
+    let anchor = parts.next()?;
+    let cursor = parts.next()?;
+
+    Some(Self { anchor, cursor })
+  }
+
+  /// Replace a selection with two other points.
+  ///
+  /// This function replaces the selection with two other points by keeping the order anchor / cursor; if the anchor is
+  /// before, the new anchor will be before; if the cursor is before the anchor, the new cursor will still be before the
+  /// new anchor.
+  pub fn replace(&self, a: &Pos, b: &Pos) -> Self {
+    if self.anchor <= self.cursor {
+      Self {
+        anchor: a.clone(),
+        cursor: b.clone(),
+      }
+    } else {
+      Self {
+        anchor: b.clone(),
+        cursor: a.clone(),
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Pos, Sel};
+
+  #[test]
+  fn pos_parsing() {
+    let s = "123.456";
+    let parsed = Pos::parse_kak_str(s);
+    assert_eq!(
+      parsed,
+      Some(Pos {
+        line: 123,
+        col: 456
+      })
+    );
+  }
+
+  #[test]
+  fn sel_parsing() {
+    let s = "123.456,124.789";
+    let parsed = Sel::parse_kak_str(s);
+    assert_eq!(
+      parsed,
+      Some(Sel {
+        anchor: Pos {
+          line: 123,
+          col: 456,
+        },
+
+        cursor: Pos {
+          line: 124,
+          col: 789
+        }
+      })
+    );
+  }
+
+  #[test]
+  fn replace_sel() {
+    let anchor_cursor = Sel {
+      anchor: Pos {
+        line: 123,
+        col: 456,
+      },
+
+      cursor: Pos {
+        line: 124,
+        col: 789,
+      },
+    };
+    let cursor_anchor = Sel {
+      anchor: Pos {
+        line: 124,
+        col: 789,
+      },
+
+      cursor: Pos {
+        line: 123,
+        col: 456,
+      },
+    };
+    let a = Pos { line: 1, col: 1 };
+    let b = Pos {
+      line: 1000,
+      col: 1000,
+    };
+
+    assert_eq!(
+      anchor_cursor.replace(&a, &b),
+      Sel {
+        anchor: Pos {
+          line: a.line,
+          col: a.col,
+        },
+
+        cursor: Pos {
+          line: b.line,
+          col: b.col
+        }
+      }
+    );
+
+    assert_eq!(
+      cursor_anchor.replace(&a, &b),
+      Sel {
+        anchor: Pos {
+          line: b.line,
+          col: b.col,
+        },
+
+        cursor: Pos {
+          line: a.line,
+          col: a.col
+        }
+      }
+    );
+  }
+}

--- a/kak-tree-sitter/src/selection.rs
+++ b/kak-tree-sitter/src/selection.rs
@@ -58,7 +58,7 @@ impl Sel {
     s.split_whitespace().flat_map(Self::parse_kak_str).collect()
   }
 
-  /// Kakoune string representatio.
+  /// Kakoune string representation.
   ///
   /// The anchor always come first; then the cursor.
   pub fn to_kak_str(&self) -> String {

--- a/kak-tree-sitter/src/selection.rs
+++ b/kak-tree-sitter/src/selection.rs
@@ -1,5 +1,6 @@
 //! Selections as recognized by Kakoune, as well as associated types and functions.
 
+use serde::{Deserialize, Serialize};
 use tree_sitter::Point;
 
 /// A single position in a buffer.
@@ -123,6 +124,13 @@ impl ObjectFlags {
     self.inner = true;
     self
   }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectMode {
+  Replace,
+  Extend,
 }
 
 #[cfg(test)]

--- a/kak-tree-sitter/src/selection.rs
+++ b/kak-tree-sitter/src/selection.rs
@@ -91,6 +91,40 @@ impl Sel {
   }
 }
 
+/// Object flags; used in object mode.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ObjectFlags {
+  pub to_begin: bool,
+  pub to_end: bool,
+  pub inner: bool,
+}
+
+impl ObjectFlags {
+  pub fn parse_kak_str(s: &str) -> Self {
+    s.split('|').fold(Self::default(), |flags, s| match s {
+      "to_begin" => flags.set_to_begin(),
+      "to_end" => flags.set_to_end(),
+      "inner" => flags.set_inner(),
+      _ => flags,
+    })
+  }
+
+  pub fn set_to_begin(mut self) -> Self {
+    self.to_begin = true;
+    self
+  }
+
+  pub fn set_to_end(mut self) -> Self {
+    self.to_end = true;
+    self
+  }
+
+  pub fn set_inner(mut self) -> Self {
+    self.inner = true;
+    self
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::{Pos, Sel};

--- a/kak-tree-sitter/src/selection.rs
+++ b/kak-tree-sitter/src/selection.rs
@@ -1,10 +1,21 @@
 //! Selections as recognized by Kakoune, as well as associated types and functions.
 
+use tree_sitter::Point;
+
 /// A single position in a buffer.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Pos {
   pub line: usize,
   pub col: usize,
+}
+
+impl From<Point> for Pos {
+  fn from(p: Point) -> Self {
+    Self {
+      line: p.row + 1,
+      col: p.column + 1,
+    }
+  }
 }
 
 impl Pos {
@@ -47,6 +58,19 @@ impl Sel {
     s.split_whitespace().flat_map(Self::parse_kak_str).collect()
   }
 
+  /// Kakoune string representatio.
+  ///
+  /// The anchor always come first; then the cursor.
+  pub fn to_kak_str(&self) -> String {
+    format!(
+      "{anchor_line}.{anchor_col},{cursor_line}.{cursor_col}",
+      anchor_line = self.anchor.line,
+      anchor_col = self.anchor.col,
+      cursor_line = self.cursor.line,
+      cursor_col = self.cursor.col
+    )
+  }
+
   /// Replace a selection with two other points.
   ///
   /// This function replaces the selection with two other points by keeping the order anchor / cursor; if the anchor is
@@ -55,13 +79,13 @@ impl Sel {
   pub fn replace(&self, a: &Pos, b: &Pos) -> Self {
     if self.anchor <= self.cursor {
       Self {
-        anchor: a.clone(),
-        cursor: b.clone(),
+        anchor: *a,
+        cursor: *b,
       }
     } else {
       Self {
-        anchor: b.clone(),
-        cursor: a.clone(),
+        anchor: *b,
+        cursor: *a,
       }
     }
   }

--- a/kak-tree-sitter/src/selection.rs
+++ b/kak-tree-sitter/src/selection.rs
@@ -1,7 +1,7 @@
 //! Selections as recognized by Kakoune, as well as associated types and functions.
 
 /// A single position in a buffer.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Pos {
   pub line: usize,
   pub col: usize,
@@ -40,6 +40,11 @@ impl Sel {
     let cursor = parts.next()?;
 
     Some(Self { anchor, cursor })
+  }
+
+  /// Parse many [`Sel`] from a space-separated list of selection.
+  pub fn parse_many(s: &str) -> Vec<Self> {
+    s.split_whitespace().flat_map(Self::parse_kak_str).collect()
   }
 
   /// Replace a selection with two other points.

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -837,7 +837,7 @@ impl FifoHandler {
           lang: lang.clone(),
           pattern: pattern.clone(),
           selections,
-          mode: *mode,
+          mode: mode.clone(),
         };
 
         Ok(None)

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -878,7 +878,7 @@ impl FifoHandler {
 
         Err(err) => {
           log::error!(
-            "handling highlight failed for session {session_name}, buffer {buf}: {err}",
+            "handling highlight failed for session {session_name}: {err}",
             session_name = session.name()
           );
         }

--- a/kak-tree-sitter/src/session.rs
+++ b/kak-tree-sitter/src/session.rs
@@ -2,6 +2,8 @@ use std::{collections::HashMap, fs::File};
 
 use mio::Token;
 
+use crate::{selection::Sel, text_objects};
+
 /// Session tracker,
 ///
 /// Responsible for tracking sessions (by names) along with the associated command token and buffer token.
@@ -141,6 +143,16 @@ pub enum SessionState {
     buffer: String,
     lang: String,
     timestamp: u64,
+  },
+
+  /// The session requested text-objects and we are waiting for the buffer content.
+  TextObjectsWaiting {
+    client: String,
+    buffer: String,
+    lang: String,
+    pattern: String,
+    selections: Vec<Sel>,
+    mode: text_objects::OperationMode,
   },
 }
 

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -8,11 +8,13 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::selection::SelectMode;
+
 /// Text-objects can be manipulated in two different ways:
 ///
 /// - In object mode, to expand selections or replace them.
 /// - To shrink selections via selecting or splitting, as in `s`, `S`, etc.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OperationMode {
   /// Search for the next text-object.
@@ -54,4 +56,62 @@ pub enum OperationMode {
   ///
   /// Similar to `<a-F>`.
   ExtendPrev,
+  /// Object mode.
+  ///
+  /// This combines select mode with object flags.
+  Object { mode: SelectMode, flags: String },
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::selection::SelectMode;
+
+  use super::OperationMode;
+
+  #[test]
+  fn deser() {
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"search_next\"").unwrap(),
+      OperationMode::SearchNext
+    );
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"search_prev\"").unwrap(),
+      OperationMode::SearchPrev
+    );
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"search_extend_next\"").unwrap(),
+      OperationMode::SearchExtendNext
+    );
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"search_extend_prev\"").unwrap(),
+      OperationMode::SearchExtendPrev
+    );
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"find_next\"").unwrap(),
+      OperationMode::FindNext
+    );
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"find_prev\"").unwrap(),
+      OperationMode::FindPrev
+    );
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"extend_next\"").unwrap(),
+      OperationMode::ExtendNext
+    );
+    assert_eq!(
+      serde_json::from_str::<OperationMode>("\"extend_prev\"").unwrap(),
+      OperationMode::ExtendPrev
+    );
+
+    assert_eq!(
+      serde_json::from_str::<OperationMode>(
+        r#"{ "object": { "mode": "replace", "flags": "to_begin|to_end|inner" }}"#
+      )
+      .unwrap(),
+      OperationMode::Object {
+        mode: SelectMode::Replace,
+        flags: "to_begin|to_end|inner".to_owned()
+      }
+    );
+  }
 }

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -16,20 +16,22 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum OperationMode {
   /// Search for the next text-object.
+  ///
+  /// Similar to `/`.
   SearchNext,
 
   /// Search for the previous text-object.
+  ///
+  /// Similar to `<a-/>`.
   SearchPrev,
 
-  /// Select the enclosing text-object (inside).
-  Inside,
+  /// Find the next text-object.
+  ///
+  /// Similar to `f`.
+  FindNext,
 
-  /// Select the enclosing text-object (around)
-  Around,
-
-  /// Select text-objects inside the selection.
-  Select,
-
-  /// Split with text-objects inside the selection.
-  Split,
+  /// Find the previous text-object.
+  ///
+  /// Similar to `<a-f>`.
+  FindPrev,
 }

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -44,4 +44,14 @@ pub enum OperationMode {
   ///
   /// Similar to `<a-f>`.
   FindPrev,
+
+  /// Extend onto the next text-object.
+  ///
+  /// Similar to `F`.
+  ExtendNext,
+
+  /// Extend onto the previous text-object.
+  ///
+  /// Similar to `<a-F>`.
+  ExtendPrev,
 }

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -25,6 +25,16 @@ pub enum OperationMode {
   /// Similar to `<a-/>`.
   SearchPrev,
 
+  /// Search-extend for the next text-object.
+  ///
+  /// Similar to `?`.
+  SearchExtendNext,
+
+  /// Search-extend for the previous text-object.
+  ///
+  /// Similar to `<a-?>`.
+  SearchExtendPrev,
+
   /// Find the next text-object.
   ///
   /// Similar to `f`.

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -1,10 +1,13 @@
 //! Text-object support.
-
-use std::fmt::Display;
+//!
+//! Requests use strings like `"function.inside"`, `"function.around"`, etc. to target specific capture groups. We do
+//! not provide a type for this, as the patterns are free and varies on the languages / grammars.
+//!
+//! However, operation modes are fixed and represent what to do with the matched parts of the buffer. For instance,
+//! [`OperationMode::Next`] will move each selection to the next matched capture group, etc.
 
 use serde::{Deserialize, Serialize};
 
-///
 /// Text-objects can be manipulated in two different ways:
 ///
 /// - In object mode, to expand selections or replace them.

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -21,3 +21,15 @@ impl Display for Level {
     f.write_str(s)
   }
 }
+
+/// Operation mode.
+///
+/// Text-objects can be manipulated in two different ways:
+///
+/// - In object mode, to expand selections or replace them.
+/// - To shrink selections via selecting or splitting, as in `s`, `S`, etc.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum OperationMode {
+  Object,
+  Shrink,
+}

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -1,0 +1,51 @@
+//! Text-object support.
+
+use std::fmt::Display;
+
+/// A text-object type.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Type {
+  pub pattern: Pattern,
+  pub level: Level,
+}
+
+impl Display for Type {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_query_name())
+  }
+}
+
+impl Type {
+  /// Return the query name representation of this text-object type.
+  pub fn as_query_name(&self) -> &'static str {
+    match (self.pattern, self.level) {
+      (Pattern::Function, Level::Inside) => "function.inside",
+      (Pattern::Function, Level::Around) => "function.around",
+      (Pattern::Parameter, Level::Inside) => "parameter.inside",
+      (Pattern::Parameter, Level::Around) => "parameter.around",
+      (Pattern::Class, Level::Inside) => "class.inside",
+      (Pattern::Class, Level::Around) => "class.around",
+      (Pattern::Comment, Level::Inside) => "comment.inside",
+      (Pattern::Comment, Level::Around) => "comment.around",
+      (Pattern::Test, Level::Inside) => "test.inside",
+      (Pattern::Test, Level::Around) => "test.around",
+    }
+  }
+}
+
+/// Text-object flavor as currently supported.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Pattern {
+  Function,
+  Parameter,
+  Class,
+  Comment,
+  Test,
+}
+
+/// Level of the text-object.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Level {
+  Inside,
+  Around,
+}

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -4,32 +4,29 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-/// Level of the text-object.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum Level {
-  Inside,
-  Around,
-}
-
-impl Display for Level {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let s = match self {
-      Level::Inside => "inside",
-      Level::Around => "around",
-    };
-
-    f.write_str(s)
-  }
-}
-
-/// Operation mode.
 ///
 /// Text-objects can be manipulated in two different ways:
 ///
 /// - In object mode, to expand selections or replace them.
 /// - To shrink selections via selecting or splitting, as in `s`, `S`, etc.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum OperationMode {
-  Object,
-  Shrink,
+  /// Find the next text-object.
+  Next,
+
+  /// Find the previous text-object.
+  Prev,
+
+  /// Select the enclosing text-object (inside).
+  Inside,
+
+  /// Select the enclosing text-object (around)
+  Around,
+
+  /// Select text-objects inside the selection.
+  Select,
+
+  /// Split with text-objects inside the selection.
+  Split,
 }

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -15,11 +15,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OperationMode {
-  /// Find the next text-object.
-  Next,
+  /// Search for the next text-object.
+  SearchNext,
 
-  /// Find the previous text-object.
-  Prev,
+  /// Search for the previous text-object.
+  SearchPrev,
 
   /// Select the enclosing text-object (inside).
   Inside,

--- a/kak-tree-sitter/src/text_objects.rs
+++ b/kak-tree-sitter/src/text_objects.rs
@@ -2,50 +2,22 @@
 
 use std::fmt::Display;
 
-/// A text-object type.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Type {
-  pub pattern: Pattern,
-  pub level: Level,
-}
-
-impl Display for Type {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.write_str(self.as_query_name())
-  }
-}
-
-impl Type {
-  /// Return the query name representation of this text-object type.
-  pub fn as_query_name(&self) -> &'static str {
-    match (self.pattern, self.level) {
-      (Pattern::Function, Level::Inside) => "function.inside",
-      (Pattern::Function, Level::Around) => "function.around",
-      (Pattern::Parameter, Level::Inside) => "parameter.inside",
-      (Pattern::Parameter, Level::Around) => "parameter.around",
-      (Pattern::Class, Level::Inside) => "class.inside",
-      (Pattern::Class, Level::Around) => "class.around",
-      (Pattern::Comment, Level::Inside) => "comment.inside",
-      (Pattern::Comment, Level::Around) => "comment.around",
-      (Pattern::Test, Level::Inside) => "test.inside",
-      (Pattern::Test, Level::Around) => "test.around",
-    }
-  }
-}
-
-/// Text-object flavor as currently supported.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum Pattern {
-  Function,
-  Parameter,
-  Class,
-  Comment,
-  Test,
-}
+use serde::{Deserialize, Serialize};
 
 /// Level of the text-object.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum Level {
   Inside,
   Around,
+}
+
+impl Display for Level {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let s = match self {
+      Level::Inside => "inside",
+      Level::Around => "around",
+    };
+
+    f.write_str(s)
+  }
 }

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -16,7 +16,8 @@ use crate::{
 ///
 /// A tree-sitter tree represents a parsed buffer in a given state. It can be walked with queries and updated.
 pub struct TreeState {
-  parser: Parser,
+  // this will be useful for #26
+  _parser: Parser,
   tree: tree_sitter::Tree,
 
   // TODO: for now, we don’t support custom highligthing, and hence have to use tree-sitter-highlight; see
@@ -36,7 +37,7 @@ impl TreeState {
     let highlighter = tree_sitter_highlight::Highlighter::new();
 
     Ok(Self {
-      parser,
+      _parser: parser,
       tree,
       highlighter,
     })

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -20,7 +20,6 @@ impl TreeState {
   pub fn new(lang: &Language, buf: &str) -> Result<Self, OhNo> {
     let mut parser = Parser::new();
     parser.set_language(lang.lang())?;
-    parser.set_timeout_micros(1000);
 
     let tree = parser
       .parse(buf.as_bytes(), None)

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -125,6 +125,16 @@ impl TreeState {
         .iter()
         .flat_map(|sel| Self::find_text_object(sel, &captures[..], true))
         .collect(),
+
+      text_objects::OperationMode::ExtendNext => selections
+        .iter()
+        .flat_map(|sel| Self::extend_text_object(sel, &captures[..], false))
+        .collect(),
+
+      text_objects::OperationMode::ExtendPrev => selections
+        .iter()
+        .flat_map(|sel| Self::extend_text_object(sel, &captures[..], true))
+        .collect(),
     };
 
     Ok(sels)
@@ -183,6 +193,19 @@ impl TreeState {
     };
     let cursor = node.node.start_position().into();
     let anchor = sel.cursor;
+
+    Some(Sel { anchor, cursor })
+  }
+
+  /// Extend onto the next/prev text-object for a given selection.
+  fn extend_text_object(sel: &Sel, captures: &[QueryCapture], is_prev: bool) -> Option<Sel> {
+    let node = if is_prev {
+      Self::node_before(&sel.cursor, captures)?
+    } else {
+      Self::node_after(&sel.cursor, captures)?
+    };
+    let cursor = node.node.start_position().into();
+    let anchor = sel.anchor;
 
     Some(Sel { anchor, cursor })
   }

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -106,6 +106,16 @@ impl TreeState {
         .flat_map(|sel| Self::search_prev_text_object(sel, &captures[..]))
         .collect(),
 
+      text_objects::OperationMode::SearchExtendNext => selections
+        .iter()
+        .flat_map(|sel| Self::search_extend_next_text_object(sel, &captures[..]))
+        .collect(),
+
+      text_objects::OperationMode::SearchExtendPrev => selections
+        .iter()
+        .flat_map(|sel| Self::search_extend_prev_text_object(sel, &captures[..]))
+        .collect(),
+
       text_objects::OperationMode::FindNext => selections
         .iter()
         .flat_map(|sel| Self::find_text_object(sel, &captures[..], false))
@@ -140,6 +150,28 @@ impl TreeState {
     end.col -= 1;
 
     Some(sel.replace(&start, &end))
+  }
+
+  /// Search-extend the next text-object for a given selection.
+  fn search_extend_next_text_object(sel: &Sel, captures: &[QueryCapture]) -> Option<Sel> {
+    let candidate = Self::node_after(&sel.cursor, captures)?;
+    let cursor = Pos::from(candidate.node.start_position());
+
+    Some(Sel {
+      anchor: sel.anchor,
+      cursor,
+    })
+  }
+
+  /// Search extend the prev text-object for a given selection.
+  fn search_extend_prev_text_object(sel: &Sel, captures: &[QueryCapture]) -> Option<Sel> {
+    let candidate = Self::node_before(&sel.cursor, captures)?;
+    let cursor = Pos::from(candidate.node.start_position());
+
+    Some(Sel {
+      anchor: sel.anchor,
+      cursor,
+    })
   }
 
   /// Find the next/prev text-object for a given selection.

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -1,0 +1,28 @@
+//! Tree-sitter state (i.e. highlighting, tree walking, etc.)
+
+use tree_sitter::{Query, QueryCursor};
+
+/// State around a tree.
+///
+/// A tree-sitter tree represents a parsed buffer in a given state. It can walked with queries and updated.
+#[derive(Debug)]
+pub struct TreeState {
+  tree: tree_sitter::Tree,
+}
+
+impl TreeState {
+  pub fn new(tree: tree_sitter::Tree) -> Self {
+    Self { tree }
+  }
+
+  pub fn query(&self, query: &Query, code: &str) {
+    let mut cursor = QueryCursor::new();
+    let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
+
+    for (query_match, size) in captures {
+      for capture in query_match.captures {
+        log::info!("--> {:?}", capture);
+      }
+    }
+  }
+}

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -1,27 +1,63 @@
 //! Tree-sitter state (i.e. highlighting, tree walking, etc.)
 
-use tree_sitter::{Query, QueryCursor};
+use tree_sitter::{Language, Parser, Query, QueryCursor};
+
+use crate::{error::OhNo, queries::Queries};
 
 /// State around a tree.
 ///
-/// A tree-sitter tree represents a parsed buffer in a given state. It can walked with queries and updated.
-#[derive(Debug)]
+/// A tree-sitter tree represents a parsed buffer in a given state. It can be walked with queries and updated.
 pub struct TreeState {
   tree: tree_sitter::Tree,
+
+  // TODO: for now, we don’t support custom highligthing, and hence have to use tree-sitter-highlight; see
+  // #26 for further information
+  highlighter: tree_sitter_highlight::Highlighter,
+  highlight_conf: tree_sitter_highlight::HighlightConfiguration,
 }
 
 impl TreeState {
-  pub fn new(tree: tree_sitter::Tree) -> Self {
-    Self { tree }
+  pub fn new(lang: Language, queries: &Queries, buf: &str) -> Result<Self, OhNo> {
+    let mut parser = Parser::new();
+    parser.set_language(lang)?;
+    parser.set_timeout_micros(1000);
+
+    let tree = parser
+      .parse(buf.as_bytes(), None)
+      .ok_or(OhNo::CannotParseBuffer)?;
+
+    let highlighter = tree_sitter_highlight::Highlighter::new();
+    let highlight_conf = tree_sitter_highlight::HighlightConfiguration::new(
+      lang,
+      queries.highlights.as_deref().unwrap_or_default(),
+      queries.injections.as_deref().unwrap_or_default(),
+      queries.locals.as_deref().unwrap_or_default(),
+    )
+    .map_err(|err| OhNo::HighlightError {
+      err: err.to_string(),
+    })?;
+
+    Ok(Self {
+      tree,
+      highlighter,
+      highlight_conf,
+    })
   }
 
   pub fn query(&self, query: &Query, code: &str) {
     let mut cursor = QueryCursor::new();
     let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
+    let names = query.capture_names();
 
     for (query_match, size) in captures {
       for capture in query_match.captures {
-        log::info!("--> {:?}", capture);
+        log::info!(
+          "--> {}: {:#?} {:?} // {:?}",
+          &code[capture.node.byte_range()],
+          capture.node.kind(),
+          names.get(capture.index as usize),
+          capture
+        );
       }
     }
   }

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -41,14 +41,7 @@ impl TreeState {
     injection_callback: impl FnMut(&str) -> Option<&'a tree_sitter_highlight::HighlightConfiguration>
       + 'a,
   ) -> Result<Vec<KakHighlightRange>, OhNo> {
-    self.text_objects(
-      lang,
-      buf,
-      text_objects::Type {
-        pattern: text_objects::Pattern::Function,
-        level: text_objects::Level::Inside,
-      },
-    )?;
+    self.text_objects(lang, buf, "function", text_objects::Level::Inside)?;
 
     let events = self
       .highlighter
@@ -64,12 +57,15 @@ impl TreeState {
     ))
   }
 
-  /// Get the text-objects for the given type.
+  /// Get the text-objects for the given pattern and level.
+  ///
+  /// This function takes in a list of selections and a mode of operation.
   pub fn text_objects(
     &self,
     lang: &Language,
     buf: &str,
-    ty: text_objects::Type,
+    pattern: &str,
+    level: text_objects::Level,
   ) -> Result<(), OhNo> {
     // first, check whether the language supports text-objects, and also check whether it has the text-object type in
     // its capture names
@@ -77,9 +73,13 @@ impl TreeState {
       .textobject_query
       .as_ref()
       .ok_or_else(|| OhNo::UnsupportedTextObjects)?;
-    let capture_index = query
-      .capture_index_for_name(ty.as_query_name())
-      .ok_or_else(|| OhNo::UnknownTextObjectQuery { ty })?;
+    let capture_index =
+      query
+        .capture_index_for_name(pattern)
+        .ok_or(OhNo::UnknownTextObjectQuery {
+          pattern: pattern.to_owned(),
+          level,
+        })?;
 
     // run the query via a query cursor
     let mut cursor = QueryCursor::new();
@@ -92,23 +92,5 @@ impl TreeState {
     log::info!("text_objects: {captures:#?}");
 
     Ok(())
-  }
-
-  pub fn query(&self, query: &Query, code: &str) {
-    let mut cursor = QueryCursor::new();
-    let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
-    let names = query.capture_names();
-
-    for (query_match, size) in captures {
-      for capture in query_match.captures {
-        log::info!(
-          "--> {}: {:#?} {:?} // {:?}",
-          &code[capture.node.byte_range()],
-          capture.node.kind(),
-          names.get(capture.index as usize),
-          capture
-        );
-      }
-    }
   }
 }

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -123,19 +123,7 @@ impl TreeState {
   /// Search the next text-object for a given selection.
   fn search_next_text_object(sel: &Sel, captures: &[QueryCapture]) -> Option<Sel> {
     let p = sel.anchor.max(sel.cursor);
-
-    // tree-sitter API here is HORRIBLE as it mutates in-place on Iterator::next(); we can’t collect();
-    //
-    // Related discussions:
-    // - <https://github.com/tree-sitter/tree-sitter/issues/2265>
-    // - <https://github.com/tree-sitter/tree-sitter/issues/608>
-    let mut candidates = captures.iter()
-      .filter(|c| Pos::from(c.node.start_position()) > p)
-      .map(|qc| qc.to_owned()) // related to the problem explained above
-      .collect::<Vec<_>>();
-
-    candidates.sort_by_key(|c| c.node.start_byte());
-    let candidate = candidates.first()?;
+    let candidate = Self::node_after(&p, captures)?;
     let start = Pos::from(candidate.node.start_position());
     let mut end = Pos::from(candidate.node.end_position());
     end.col -= 1;
@@ -146,15 +134,7 @@ impl TreeState {
   /// Search the prev text-object for a given selection.
   fn search_prev_text_object(sel: &Sel, captures: &[QueryCapture]) -> Option<Sel> {
     let p = sel.anchor.min(sel.cursor);
-
-    // same shit as previously
-    let mut candidates = captures.iter()
-      .filter(|c| Pos::from(c.node.start_position()) < p)
-      .map(|qc| qc.to_owned()) // related to the problem explained above
-      .collect::<Vec<_>>();
-
-    candidates.sort_by_key(|c| c.node.start_byte());
-    let candidate = candidates.last()?;
+    let candidate = Self::node_before(&p, captures)?;
     let start = Pos::from(candidate.node.start_position());
     let mut end = Pos::from(candidate.node.end_position());
     end.col -= 1;
@@ -177,6 +157,11 @@ impl TreeState {
 
   /// Get the next node after given position.
   fn node_after<'a>(p: &Pos, captures: &[QueryCapture<'a>]) -> Option<QueryCapture<'a>> {
+    // tree-sitter API here is HORRIBLE as it mutates in-place on Iterator::next(); we can’t collect();
+    //
+    // Related discussions:
+    // - <https://github.com/tree-sitter/tree-sitter/issues/2265>
+    // - <https://github.com/tree-sitter/tree-sitter/issues/608>
     let mut candidates = captures.iter()
       .filter(|c| &Pos::from(c.node.start_position()) > p)
       .map(|qc| qc.to_owned()) // related to the problem explained above
@@ -188,6 +173,11 @@ impl TreeState {
 
   /// Get the previous node before a given position.
   fn node_before<'a>(p: &Pos, captures: &[QueryCapture<'a>]) -> Option<QueryCapture<'a>> {
+    // tree-sitter API here is HORRIBLE as it mutates in-place on Iterator::next(); we can’t collect();
+    //
+    // Related discussions:
+    // - <https://github.com/tree-sitter/tree-sitter/issues/2265>
+    // - <https://github.com/tree-sitter/tree-sitter/issues/608>
     let mut candidates = captures.iter()
       .filter(|c| &Pos::from(c.node.start_position()) < p)
       .map(|qc| qc.to_owned()) // related to the problem explained above


### PR DESCRIPTION
Text-objects are supported natively by KTS by sending several selections. As such, they work for every selection. Many features are supported, which are similar to keys already defined in Kakoune:

- `f` / `<a-f>`: find the next text-object.
- `F` / `<a-F>`: extend onto the next text-object.
- `/` / `<a-/>`: search for the next text-object.
- `?` / `<a-?>`: search-extend onto the next text-object.
- Full object mode support.

Additionally, a new CLI flag was added, `--with-text-objects`, which creates user-modes for users to start testing tree-sitter text-objects without having to think too much about it, and injects object mode maps:

- `tree-sitter` is the user-mode to use to get access to most text-objects listed above.
- In object mode:
  - `f` for functions.
  - `t` for types.
  - `c` for comments.
  - `T` for tests.

A wiki update is planned to list all the possible commands / options so that people who would like to craft their own keybindings / user-modes can do it easily.