### PR TITLE
Support reading local paths when used as sources for both grammars & queries.

### DIFF
--- a/docs/man/configuration.md
+++ b/docs/man/configuration.md
@@ -67,7 +67,7 @@ This section provides the required data to know how to fetch queries.
 
 Sources are a way to provide information from where runtime resources come from. We currently support two sources:
 
-- Local paths (`path`).
+- Local paths (`local.path`).
 - And Git repositories (`git`), which is an object containing the following fields:
   - `url`: the URL to fetch from. Will use `git clone`.
   - `pin`: _pin ref_, such as a commit, branch name or tag. **Highly recommended** to prevent breakage.
@@ -80,10 +80,10 @@ If you decide to use a `git` source:
 - When you decide to install a “language”, both the grammars and queries might be fetched, compiled and installed if
   the configuration requires both to be. Hence, a single CLI command should basically do everything for you.
 
-If you decide to use a `path` source, **`ktsctl` will do nothing for you** and will simply display a message explaining
+If you decide to use a `local` source, **`ktsctl` will do nothing for you** and will simply display a message explaining
 that it will use a path. Nothing will be fetched, compiled nor installed. It’s up to you to do so.
 
 For users installing `ktsctl` by using a binary release or compiling it themselves, the default configuration (which
 uses mainly `git` sources) is enough. However, if you ship with a distributed set of grammars and queries, you might
-want to override the languages’ configurations and use `path` sources. You can also mix them: a `git` source for the
-grammar, and a `path` one for the queries. It’s up to you.
+want to override the languages’ configurations and use `local` sources. You can also mix them: a `git` source for the
+grammar, and a `local` one for the queries. It’s up to you.

--- a/kak-tree-sitter-config/src/lib.rs
+++ b/kak-tree-sitter-config/src/lib.rs
@@ -149,15 +149,27 @@ impl LanguagesConfig {
   }
 
   /// Get the grammar path for a given language.
-  pub fn get_grammar_path(lang: impl AsRef<str>) -> Option<PathBuf> {
-    let lang = lang.as_ref();
-    dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/grammars/{lang}.so")))
+  pub fn get_grammar_path(lang_config: &LanguageConfig, lang: impl AsRef<str>) -> Option<PathBuf> {
+    match lang_config.grammar.source {
+      Source::Local { path: ref dir } => Some(dir.clone()),
+
+      Source::Git { .. } => {
+        let lang = lang.as_ref();
+        dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/grammars/{lang}.so")))
+      }
+    }
   }
 
   /// Get the queries directory for a given language.
-  pub fn get_queries_dir(lang: impl AsRef<str>) -> Option<PathBuf> {
-    let lang = lang.as_ref();
-    dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/queries/{lang}")))
+  pub fn get_queries_dir(lang_config: &LanguageConfig, lang: impl AsRef<str>) -> Option<PathBuf> {
+    match lang_config.queries.source {
+      Some(Source::Local { path: ref dir }) => Some(dir.clone()),
+
+      _ => {
+        let lang = lang.as_ref();
+        dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/queries/{lang}")))
+      }
+    }
   }
 }
 
@@ -472,7 +484,7 @@ mod tests {
           "rust".to_owned(),
           LanguageConfig {
             grammar: LanguageGrammarConfig {
-              source: Source::path("file://hello"),
+              source: Source::local("file://hello"),
               path: PathBuf::from("src"),
               compile: "".to_owned(),
               compile_args: Vec::default(),

--- a/kak-tree-sitter-config/src/source.rs
+++ b/kak-tree-sitter-config/src/source.rs
@@ -8,14 +8,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Source {
-  Path { dir: PathBuf },
+  Local { path: PathBuf },
   Git { url: String, pin: Option<String> },
 }
 
 impl Source {
-  pub fn path(dir: impl Into<PathBuf>) -> Self {
-    let dir = dir.into();
-    Self::Path { dir }
+  pub fn local(path: impl Into<PathBuf>) -> Self {
+    let path = path.into();
+    Self::Local { path }
   }
 
   pub fn git(url: impl Into<String>, pin: impl Into<Option<String>>) -> Self {

--- a/kak-tree-sitter/src/languages.rs
+++ b/kak-tree-sitter/src/languages.rs
@@ -69,7 +69,7 @@ impl Languages {
     for (lang_name, lang_config) in &config.languages.language {
       log::info!("loading configuration for {lang_name}");
 
-      if let Some(grammar_path) = LanguagesConfig::get_grammar_path(lang_name) {
+      if let Some(grammar_path) = LanguagesConfig::get_grammar_path(lang_config, lang_name) {
         log::info!("  grammar path: {}", grammar_path.display());
 
         let (ts_lib, ts_lang) = match Self::load_grammar(lang_name, &grammar_path) {
@@ -80,7 +80,7 @@ impl Languages {
           }
         };
 
-        if let Some(queries_dir) = LanguagesConfig::get_queries_dir(lang_name) {
+        if let Some(queries_dir) = LanguagesConfig::get_queries_dir(lang_config, lang_name) {
           log::info!("  queries directory: {}", queries_dir.display());
 
           let queries = Queries::load_from_dir(queries_dir);

--- a/ktsctl/src/main.rs
+++ b/ktsctl/src/main.rs
@@ -216,10 +216,13 @@ fn manage(
 
   // grammar
   match lang_config.grammar.source {
-    Source::Path { ref dir } => {
+    Source::Local { ref path } => {
       Report::new(
         ReportIcon::Info,
-        format!("using local grammar {lang} at {dir}", dir = dir.display()),
+        format!(
+          "using local grammar {lang} at {path}",
+          path = path.display()
+        ),
       );
     }
 
@@ -236,10 +239,13 @@ fn manage(
 
   // queries
   match lang_config.queries.source {
-    Some(Source::Path { ref dir }) => {
+    Some(Source::Local { ref path }) => {
       Report::new(
         ReportIcon::Info,
-        format!("using local queries {lang} at {dir}", dir = dir.display()),
+        format!(
+          "using local queries {lang} at {path}",
+          path = path.display()
+        ),
       );
     }
 
@@ -381,11 +387,11 @@ fn delim(d: impl Display) -> impl Display {
 
 fn display_source(source: &Source) {
   match source {
-    Source::Path { dir } => {
+    Source::Local { path } => {
       println!(
         "  {} {}",
         config_field("Source (path)"),
-        format!("{}", dir.display()).green()
+        format!("{}", path.display()).green()
       );
     }
 


### PR DESCRIPTION
That was something missing to fully finish implementing #34.