### PR TITLE
Flush after try_enable_highlight fifo cmd

### DIFF
--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -112,7 +112,10 @@ define-command -hidden kak-tree-sitter-set-lang %{
 # Send a request to KTS to enable kak-tree-sitter.
 define-command kak-tree-sitter-req-enable -docstring 'Send request to enable tree-sitter support' %{
   kak-tree-sitter-set-lang
-  echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""try_enable_highlight"", ""lang"": ""%opt{kts_lang}"", ""client"": ""%val{client}"" }"
+  evaluate-commands -no-hooks %{
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""try_enable_highlight"", ""lang"": ""%opt{kts_lang}"", ""client"": ""%val{client}"" }"
+    write %opt{kts_cmd_fifo_path}
+  }
 }
 
 # Initiate request.


### PR DESCRIPTION
When highlighting is messed up #223 , the server reports a mailformed `try_enable_highlight` message.
```
[ERROR]: malformed request: invalid request { "type": "try_enable_highlight", "lang": "cpp", "client": "client0" }{ "type": "try_enable_highlight", "lang": "cpp", "client": "client0" }: trailing characters at line 1 column 71'
```
Note: This is not the only error message. Sometimes, the invalid request is an empty or one character string. Or, more common `invalid request : EOF while parsing a value at line 1 column 0'`.
With this change we, *I believe*, force a flush on the fifo buffer.