### PR TITLE
Attempt to remove previous state when starting the server

### DIFF
--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -74,22 +74,9 @@ impl Server {
         log::debug!("kak-tree-sitter already running; not starting a new server");
         return Ok(());
       } else {
-        log::debug!("removing previous PID file");
-        std::fs::remove_file(&pid_file).map_err(|err| OhNo::CannotStartDaemon {
-          err: format!(
-            "cannot remove previous PID file {path}: {err}",
-            path = pid_file.display()
-          ),
-        })?;
-
-        log::debug!("removing previous socket file");
-        let socket_file = runtime_dir.join("socket");
-        std::fs::remove_file(&socket_file).map_err(|err| OhNo::CannotStartDaemon {
-          err: format!(
-            "cannot remove previous socket file {path}: {err}",
-            path = socket_file.display()
-          ),
-        })?;
+        log::debug!("removing previous state");
+        // If there is no previous state then ignore
+        let _ = fs::remove_dir_all(&runtime_dir);
       }
     }
 


### PR DESCRIPTION
While attempting to figure out why highlighting is getting screwed unpredictably #223 , I send out #314 but this introduced error messages on startup when launching kakoune. Hence, this change is more radical. I suspect that previous sockets/buffers/fifos remain which corrupt new sessions. This is a "quickfix" to simply remove all previous state. @hadronized I assume there is a reason why you didn't do this in the first place.

So far, this has been the only fix that is 100% reliable for me.